### PR TITLE
Fix Accessibility Insights problem: 'The name property must not contain only space characters'

### DIFF
--- a/Composer/packages/client/src/pages/home/Home.tsx
+++ b/Composer/packages/client/src/pages/home/Home.tsx
@@ -207,7 +207,7 @@ const Home: React.FC<RouteComponentProps> = () => {
             )}
           </div>
           <div css={home.resourcesContainer}>
-            <h2 css={home.subtitle}>{formatMessage('Resources')}&nbsp;</h2>
+            <h2 css={home.subtitle}>{formatMessage('Resources')}</h2>
             <div css={home.rowContainer}>
               {resources.map((item, index) => (
                 <CardWidget


### PR DESCRIPTION
## Description
As reported at the issue, the error 'The name property must not contain only space characters' is reported on the Home page in Composer.

## Changes made
Removed one non-breaking space character after the 'Resources' header.

## Screenshots
No noticeable UI changes.

## Testing
There were no need to update unit tests.
