### PR TITLE
Fix: [Create Bot Page] An element with LocalizedLandmarkType "main" must not descend from another landmark

### DIFF
--- a/Composer/packages/client/src/pages/design/DesignPage.tsx
+++ b/Composer/packages/client/src/pages/design/DesignPage.tsx
@@ -55,7 +55,7 @@ const DesignPage: React.FC<RouteComponentProps<{ dialogId: string; projectId: st
           </div>
         </div>
 
-        <div css={contentWrapper} role="main">
+        <div css={contentWrapper}>
           <CommandBar projectId={activeBot} />
           <Conversation css={splitPaneContainer}>
             <div css={splitPaneWrapper}>


### PR DESCRIPTION
## Description

As reported at the issue, the error 'An element with LocalizedLandmarkType "main" must not descend from another landmark' was reported on the Create Bot page in Composer.

## Changes made
- Removed the duplicated `role="main"` attribute as the parent DIV is already using this same role.

## Screenshots

Error detected
![imagen](https://user-images.githubusercontent.com/62261539/136251411-ebbd6b97-9ee3-434a-9c16-533ca5c935e9.png)

Element with error
![imagen](https://user-images.githubusercontent.com/62261539/136251256-5d6f2991-2dd0-4091-9fed-d9ebdee0f3f5.png)
