### PR TITLE
Add missing roles

### DIFF
--- a/Composer/packages/client/src/pages/home/RecentBotList.tsx
+++ b/Composer/packages/client/src/pages/home/RecentBotList.tsx
@@ -33,6 +33,7 @@ export function RecentBotList(props: RecentBotListProps): JSX.Element {
     {
       key: 'column1',
       name: formatMessage('Name'),
+      role: 'columnheader',
       fieldName: 'name',
       minWidth: 150,
       maxWidth: 200,
@@ -41,7 +42,7 @@ export function RecentBotList(props: RecentBotListProps): JSX.Element {
       data: 'string',
       onRender: (item) => {
         return (
-          <div data-is-focusable css={home.tableCell}>
+          <div data-is-focusable css={home.tableCell} role="columnheader">
             <Link
               aria-label={formatMessage(`Bot name is {botName}`, { botName: item.name })}
               onClick={() => onItemChosen(item)}
@@ -56,6 +57,7 @@ export function RecentBotList(props: RecentBotListProps): JSX.Element {
     {
       key: 'column2',
       name: formatMessage('Location'),
+      role: 'columnheader',
       fieldName: 'path',
       minWidth: 200,
       maxWidth: 400,
@@ -63,10 +65,11 @@ export function RecentBotList(props: RecentBotListProps): JSX.Element {
       data: 'string',
       onRender: (item) => {
         return (
-          <div data-is-focusable css={home.tableCell}>
+          <div data-is-focusable css={home.tableCell} role="columnheader">
             <div
               aria-label={formatMessage(`location is {location}`, { location: item.path })}
               css={home.content}
+              role="row"
               tabIndex={-1}
             >
               {item.path}
@@ -79,6 +82,7 @@ export function RecentBotList(props: RecentBotListProps): JSX.Element {
     {
       key: 'column3',
       name: formatMessage('Date modified'),
+      role: 'columnheader',
       fieldName: 'dateModifiedValue',
       minWidth: 60,
       maxWidth: 70,
@@ -86,10 +90,11 @@ export function RecentBotList(props: RecentBotListProps): JSX.Element {
       data: 'number',
       onRender: (item) => {
         return (
-          <div data-is-focusable css={home.tableCell}>
+          <div data-is-focusable css={home.tableCell} role="columnheader">
             <div
               aria-label={formatMessage(`Last modified time is {time}`, { time: calculateTimeDiff(item.dateModified) })}
               css={home.content}
+              role="row"
               tabIndex={-1}
             >
               {calculateTimeDiff(item.dateModified)}


### PR DESCRIPTION
## Description

As reported in the issue, the error 'The LocalizedControlType property must not be null' was reported on the Home page in Composer.

## Changes made

We added the missing roles for the Bot name, Location and Modified date properties (role="columnheader" and role="row").

## Screenshots

No noticeable UI changes.
