### PR TITLE
Fix: [Create Bot Page]: Focusable sibling elements must not have the same Name and LocalizedControlType.

### DIFF
--- a/Composer/packages/adaptive-form/src/components/fields/BooleanField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/BooleanField.tsx
@@ -75,6 +75,7 @@ const BooleanField: React.FC<FieldProps> = function CheckboxWidget(props) {
         id={id}
         options={options}
         responsiveMode={ResponsiveMode.large}
+        role={'dropdown'}
         selectedKey={selectedKey}
         styles={{
           root: { width: '100%' },


### PR DESCRIPTION
## Description

As reported in the issue, the error 'Focusable sibling elements must not have the same Name and LocalizedControlType' was reported on the Create Bot page in Composer.

## Changes made

We added the missing role for the booleanFields properties (role="dropdown").

## Screenshots

No noticeable UI changes.
