### PR TITLE
Fix: [Create Bot Page]: The name property must not contain only space characters.

### DIFF
--- a/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/widgets/ActionCard/ActionCardBody.tsx
+++ b/Composer/packages/adaptive-flow/src/adaptive-flow-renderer/widgets/ActionCard/ActionCardBody.tsx
@@ -45,7 +45,7 @@ export const ActionCardBody: WidgetComponent<ActionCardBodyProps> = ({ body, tru
   return (
     <div css={containerStyle()}>
       {!hideComment && flowCommentsVisible && comment && <CardComment comment={comment} />}
-      <div css={textStyles(undefined, truncate)}>{body || ' '}</div>
+      <div css={textStyles(undefined, truncate)}>{body || ''}</div>
     </div>
   );
 };


### PR DESCRIPTION
## Description

As reported in the issue, the error 'The name property must not contain only space characters' was reported on the Create Bot page in Composer.

## Changes made

We removed the space character on the user input name

## Screenshots

No noticeable UI changes.
