### PR TITLE
fix: [Create Bot Page] The name property of a focusable element must not be null.

### DIFF
--- a/Composer/packages/adaptive-form/src/components/fields/BooleanField.tsx
+++ b/Composer/packages/adaptive-form/src/components/fields/BooleanField.tsx
@@ -72,6 +72,7 @@ const BooleanField: React.FC<FieldProps> = function CheckboxWidget(props) {
       />
       <Dropdown
         ariaLabel={label || formatMessage('boolean field')}
+        aria-hidden={selectedKey === '' ? true : false}
         id={id}
         options={options}
         responsiveMode={ResponsiveMode.large}

--- a/Composer/packages/client/src/components/Split/ThinSplitter.tsx
+++ b/Composer/packages/client/src/components/Split/ThinSplitter.tsx
@@ -45,7 +45,13 @@ export const ThinSplitter = (props: RenderSplitterProps) => {
 
   return (
     <HitArea dragging={dragging} horizontal={horizontal}>
-      <Splitter className={splitVisualClassName} dragging={dragging} horizontal={horizontal} splitterSize={pixelSize} />
+      <Splitter
+        aria-label="Splitter"
+        className={splitVisualClassName}
+        dragging={dragging}
+        horizontal={horizontal}
+        splitterSize={pixelSize}
+      />
     </HitArea>
   );
 };

--- a/Composer/packages/client/src/pages/design/DebugPanel/DebugPanel.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/DebugPanel.tsx
@@ -162,6 +162,7 @@ export const DebugPanel: React.FC = () => {
             {headerPivot}
           </div>
           <div
+            aria-label="Debug Panel"
             css={{ flexGrow: 1, cursor: 'pointer', outline: 'none' }}
             data-testid="header__blank"
             role="button"


### PR DESCRIPTION
## Description

As reported in the issue, the error 'The name property of a focusable element must not be null' was fixed by adding additional aria attributes to some elements.

## Changes made

- Added aria-label attribute
- Added aria-hidden conditionally based on the element's value

## Screenshots

The error is not reported anymore
![imagen](https://user-images.githubusercontent.com/62261539/137015884-fca38b5d-efa7-47d9-80e4-a123e6306b56.png)

#minor