### PR TITLE
Fix null name in Configure Bot page

### DIFF
--- a/Composer/packages/client/src/components/Split/ThinSplitter.tsx
+++ b/Composer/packages/client/src/components/Split/ThinSplitter.tsx
@@ -45,7 +45,13 @@ export const ThinSplitter = (props: RenderSplitterProps) => {
 
   return (
     <HitArea dragging={dragging} horizontal={horizontal}>
-      <Splitter className={splitVisualClassName} dragging={dragging} horizontal={horizontal} splitterSize={pixelSize} />
+      <Splitter
+        className={splitVisualClassName}
+        dragging={dragging}
+        horizontal={horizontal}
+        splitterSize={pixelSize}
+        title="Splitter"
+      />
     </HitArea>
   );
 };

--- a/Composer/packages/client/src/pages/design/DebugPanel/DebugPanel.tsx
+++ b/Composer/packages/client/src/pages/design/DebugPanel/DebugPanel.tsx
@@ -166,6 +166,7 @@ export const DebugPanel: React.FC = () => {
             data-testid="header__blank"
             role="button"
             tabIndex={0}
+            title="Debug Panel"
             onClick={onDebugPaneClick}
             onKeyPress={onDebugPaneClick}
           />


### PR DESCRIPTION
## Description
As reported in the issue, the error 'The name property of a focusable element must not be null' appeared for two components in the Configure Bot page when analyzed with the Accessibility Insights tool.


## Task Item
N/A

## Screenshots

No noticeable UI changes.
