### PR TITLE
Fix: [User Input Page]: An element must not have the same Name and LocalizedControlType as its parent.

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
@@ -465,6 +465,7 @@ export const TreeItem: React.FC<ITreeItemProps> = ({
             data-is-focusable
             aria-label={`${ariaLabel} ${warningContent} ${errorContent}`}
             css={projectTreeItemContainer}
+            role={'treeitem'}
             tabIndex={0}
             onBlur={item.onBlur}
             onFocus={item.onFocus}


### PR DESCRIPTION
## Description
As noted by the issue, the message 'An element must not have the same Name and LocalizedControlType as its parent.' would be reported at the User Input page.

## Changes made
Added role to treeItem.

## Screenshots
No noticeable UI changes.
