### PR TITLE
Fix: [QnA Page]: An element must not have the same Name and LocalizedControlType as its parent

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
@@ -463,7 +463,7 @@ export const TreeItem: React.FC<ITreeItemProps> = ({
         <TreeItemContent tooltip={link.tooltip}>
           <div
             data-is-focusable
-            aria-label={`${ariaLabel} ${warningContent} ${errorContent}`}
+            aria-label={`${ariaLabel} ${warningContent} ${errorContent}.`}
             css={projectTreeItemContainer}
             tabIndex={0}
             onBlur={item.onBlur}


### PR DESCRIPTION
## Description

As reported in the issue, the error 'An element must not have the same Name and LocalizedControlType as its parent' was reported on the Create Bot page in Composer.

## Task Item

We added a punctuation mark at the end of the aria-label 

## Screenshots

No noticeable UI changes.