### PR TITLE
Fix: [Package Manager Page]: The name property must not contain only space characters

### DIFF
--- a/extensions/packageManager/src/pages/Library.tsx
+++ b/extensions/packageManager/src/pages/Library.tsx
@@ -105,7 +105,7 @@ const Library: React.FC = () => {
   const strings = {
     title: formatMessage('Package Manager'),
     editFeeds: formatMessage('Edit feeds'),
-    description: formatMessage('Discover and use components that can be installed into your bot.'),
+    description: formatMessage('Discover and use components that can be installed into your bot. '),
     descriptionLink: formatMessage('Learn more'),
     viewDocumentation: formatMessage('View documentation'),
     installButton: formatMessage('Install'),
@@ -611,7 +611,7 @@ const Library: React.FC = () => {
       <div css={ContentHeaderStyle}>
         <h1 css={HeaderText}>{strings.title}</h1>
         <p>
-          {strings.description}&nbsp;
+          {strings.description}
           <Link href={docsUrl} target="_new">
             {strings.descriptionLink}
           </Link>


### PR DESCRIPTION
## Description

As reported in the issue, the error 'The name property must not contain only space characters' was reported on the Package Manager Page in Composer.

## Changes made

We removed the non breaking space character and added a space on the text shown before.

## Screenshots

No noticeable UI changes.
