### PR TITLE
fix: [Package ManagerBot Page] The name property of an element should not contain class names like 'Microsoft.*.'

### DIFF
--- a/extensions/packageManager/src/components/LibraryList.tsx
+++ b/extensions/packageManager/src/components/LibraryList.tsx
@@ -100,7 +100,9 @@ export const LibraryList: React.FC<ILibraryListProps> = (props) => {
       onRender: (item: LibraryRef) => {
         return (
           <Fragment>
-            <span style={{ display: 'block', fontWeight: 'bold', lineHeight: '150%' }}>{item.name}</span>
+            <span aria-label={item.name} style={{ display: 'block', fontWeight: 'bold', lineHeight: '150%' }}>
+              {item.name}
+            </span>
             <span>{item.description}</span>
           </Fragment>
         );


### PR DESCRIPTION
## Description

As reported in the issue, the error 'The name property of an element should not contain class names like 'Microsoft.*.' as these are not usually informative.' was fixed by adding an additional `aria-label` to each item included in the packages list.

## Changes made

- Added aria-label attribute for each package

## Screenshots

No tests modified.

#minor