### PR TITLE
fix: [Use Input Page]: The LocalizedControlType property must not be null

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
@@ -462,6 +462,7 @@ export const TreeItem: React.FC<ITreeItemProps> = ({
       return (
         <TreeItemContent tooltip={link.tooltip}>
           <div
+            role="region"
             data-is-focusable
             aria-label={`${ariaLabel} ${warningContent} ${errorContent}`}
             css={projectTreeItemContainer}
@@ -469,7 +470,7 @@ export const TreeItem: React.FC<ITreeItemProps> = ({
             onBlur={item.onBlur}
             onFocus={item.onFocus}
           >
-            <div css={projectTreeItem} role="presentation" tabIndex={-1}>
+            <div css={projectTreeItem} role="region" tabIndex={-1}>
               {item.itemType != null && TreeIcons[item.itemType] != null && (
                 <Icon
                   iconName={TreeIcons[item.itemType]}
@@ -565,7 +566,7 @@ export const TreeItem: React.FC<ITreeItemProps> = ({
       aria-label={ariaLabel}
       css={navContainer(isMenuOpen, isActive, thisItemSelected, textWidth - overflowIconWidthOnHover, isBroken)}
       data-testid={dataTestId}
-      role={role}
+      role={'region'}
       tabIndex={0}
       onClick={
         onSelect

--- a/Composer/packages/client/src/pages/language-understanding/table-view.tsx
+++ b/Composer/packages/client/src/pages/language-understanding/table-view.tsx
@@ -195,6 +195,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         minWidth: 100,
         maxWidth: 200,
         isResizable: true,
+        isCollapsable: true,
         data: 'string',
         onRender: (item: Intent) => {
           const displayName = `#${item.name}`;
@@ -227,6 +228,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         fieldName: 'phrases',
         minWidth: 500,
         isResizable: true,
+        isCollapsable: true,
         data: 'string',
         onRender: (item) => {
           const text = item.phrases;
@@ -298,7 +300,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         onRender: (item) => {
           const text = item[`body-${defaultLanguage}`];
           return (
-            <div data-is-focusable css={luPhraseCell}>
+            <div data-is-focusable css={luPhraseCell} role="columnheader">
               <EditableField
                 multiline
                 ariaLabel={formatMessage(`Sample Phrases are {phrases}`, { phrases: text })}


### PR DESCRIPTION
## Description

As reported in the issue, the error 'The LocalizedControlType property must not be null.' was fixed by adding an aria role and some custom properties.

## Changes made

- Added aria role for columns and node items
- Set isCollapsable property to some column headers

## Screenshots

No tests modified.

#minor