### PR TITLE
fix: [Bot Responses Page]: The LocalizedControlType property must not be null

### DIFF
--- a/Composer/packages/client/src/pages/language-generation/table-view.tsx
+++ b/Composer/packages/client/src/pages/language-generation/table-view.tsx
@@ -207,7 +207,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         onRender: (item) => {
           const displayName = `#${item.name}`;
           return (
-            <div data-is-focusable css={formCell}>
+            <div data-is-focusable css={formCell} role="row">
               <EditableField
                 ariaLabel={formatMessage(`Name is {name}`, { name: displayName })}
                 containerStyles={editableFieldContainer}
@@ -234,11 +234,12 @@ const TableView: React.FC<TableViewProps> = (props) => {
         fieldName: 'responses',
         minWidth: 500,
         isResizable: true,
+        isCollapsible: true,
         data: 'string',
         onRender: (item) => {
           const text = item.body;
           return (
-            <div data-is-focusable css={formCell}>
+            <div data-is-focusable css={formCell} role="row">
               <EditableField
                 multiline
                 ariaLabel={formatMessage(`Response is {response}`, { response: text })}


### PR DESCRIPTION
### Description
As reported in the issue, the error 'The LocalizedControlType property must not be null' was reported on the Bot responses page in Composer.

### Changes made
We set the property isCollapsible to true in order to fix the Responses header error. Also, we added the missing roles (role="row").

### Screenshots
Total errors
![pr 3](https://user-images.githubusercontent.com/64086728/139463142-dc5edaf8-e92d-4767-86b3-889a06b7c717.png)

Errors fixed with this PR
![pr 4](https://user-images.githubusercontent.com/64086728/139463176-32bc395e-575f-4584-84b0-2ec66e5a3b63.png)

#minor