### PR TITLE
fix: [QnA Page]: The LocalizedControlType property must not be null

### DIFF
--- a/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
+++ b/Composer/packages/client/src/pages/knowledge-base/table-view.tsx
@@ -688,6 +688,7 @@ const TableView: React.FC<TableViewProps> = (props) => {
         fieldName: 'answer',
         minWidth: 350,
         isResizable: true,
+        isCollapsible: true,
         data: 'string',
         onRender: (item, index) => {
           const isSourceSectionInDialog =


### PR DESCRIPTION
### Description
As reported in the issue, the error 'The LocalizedControlType property must not be null.' was reported on the QnA page in Composer.

### Changes made
We set the property isCollapsible to true in order to fix the Answer header error.

### Screenshots
Total errors
![pr 1](https://user-images.githubusercontent.com/64086728/139464279-488e7b58-fdd3-43a2-8403-fc2613e44054.png)

Errors fixed with this PR
![pr 2](https://user-images.githubusercontent.com/64086728/139464299-c7e70f9d-9816-469f-9692-c6581fcc4f45.png)

#minor