### PR TITLE
[#9163] E2E test failing in Composer DevOps pipeline

### DIFF
--- a/Composer/packages/integration-tests/cypress/support/commands.ts
+++ b/Composer/packages/integration-tests/cypress/support/commands.ts
@@ -3,6 +3,7 @@
 
 import '@testing-library/cypress/add-commands';
 
+const COMMAND_DELAY = 500;
 let TemplateBotProjectId = '';
 
 Cypress.Commands.add('createBot', (botName: string, callback?: (bot: any) => void) => {
@@ -89,3 +90,10 @@ Cypress.on('uncaught:exception', (err) => {
   console.log('uncaught exception', err);
   return false;
 });
+
+for (const command of ['visit', 'click', 'type', 'clear']) {
+  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
+    const origVal = originalFn(...args);
+    return new Promise((resolve) => setTimeout(() => resolve(origVal), COMMAND_DELAY));
+  });
+}


### PR DESCRIPTION
Fixes # 9163

## Description
This PR adds a small delay to multiple commands that may cause timeout issues when executing cypress tests.

## Specific Changes
- Adds an override cypress commands to perform a small delay of `500ms`.

## Testing
The following images show the reproduced error captured from the generated video and the pipeline comparison between having and don't having the delay.
![image](https://user-images.githubusercontent.com/62260472/174157011-764a5af4-b999-428a-8d71-9b8fc3b97790.png)
![image](https://user-images.githubusercontent.com/62260472/174156964-96c201dd-e337-4eb7-8ced-74d4fc6139d5.png)