### PR TITLE
[#9207] Entering hyphen as second character in resource name causes provisioning to fail

### DIFF
--- a/extensions/azurePublish/src/components/api.tsx
+++ b/extensions/azurePublish/src/components/api.tsx
@@ -451,7 +451,7 @@ export const getPreview = (hostname: string): PreviewResourcesItem[] => {
   const blobStorageName = hostname.toLowerCase().replace(/-/g, '').replace(/_/g, '');
   const luisResourceName = `${hostname}-luis`;
   const luisAuthoringName = `${hostname}-luis-authoring`;
-  const qnaAccountName = `${hostname}-qna`;
+  const qnaAccountName = `${hostname.toLowerCase().replace(/-/g, '').replace(/_/g, '')}-qna`;
   const applicationInsightsName = `${hostname}`;
 
   const previewList = [

--- a/extensions/azurePublish/src/node/provision.ts
+++ b/extensions/azurePublish/src/node/provision.ts
@@ -422,7 +422,7 @@ export class BotProjectProvision {
             provisionResults.qna = await this.azureResourceManagementClient.deployQnAReource({
               resourceGroupName: resourceGroupName,
               location: config.location ?? provisionResults.resourceGroup.location,
-              name: config.hostname,
+              name: config.hostname.toLowerCase().replace(/-/g, '').replace(/_/g, ''),
             });
             break;
 

--- a/extensions/azurePublishNew/src/hooks/useResourcesApi.ts
+++ b/extensions/azurePublishNew/src/hooks/useResourcesApi.ts
@@ -32,7 +32,7 @@ export const useResourcesApi = () => {
     const blobStorageName = hostname.toLowerCase().replace(/-/g, '').replace(/_/g, '');
     const luisResourceName = `${hostname}-luis`;
     const luisAuthoringName = `${hostname}-luis-authoring`;
-    const qnaAccountName = `${hostname}-qna`;
+    const qnaAccountName = `${hostname.toLowerCase().replace(/-/g, '').replace(/_/g, '')}-qna`;
     const applicationInsightsName = `${hostname}`;
 
     const previewList = [


### PR DESCRIPTION
## Description
This PR fixes the provisioning failure when there're hyphens in the resource name for QnAMaker.
The name of the QnA resources is now formatted (lowercase and hyphens removed) to meet the requisites for the _Azure Search Service_ name.

## Task Item
Fixes # 9207

## Screenshots
Here we can see how the QnA Maker name is formatted and the provisioning completed successfully.
![image](https://user-images.githubusercontent.com/44245136/176258332-d8e42b97-2e72-4ada-8c19-9f2a7c5be35c.png)