### PR TITLE
feat: [#8787] Update ARM templates and test

### DIFF
--- a/extensions/samples/assets/shared/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
+++ b/extensions/samples/assets/shared/scripts/DeploymentTemplates/function-template-with-preexisting-rg.json
@@ -162,9 +162,7 @@
           "name": "appsettings",
           "type": "config",
           "apiVersion": "2015-08-01",
-          "dependsOn": [
-            "[concat('Microsoft.Web/Sites/', variables('webAppName'))]"
-          ],
+          "dependsOn": ["[concat('Microsoft.Web/Sites/', variables('webAppName'))]"],
           "properties": {
             "FUNCTIONS_EXTENSION_VERSION": "~3",
             "FUNCTIONS_WORKER_RUNTIME": "dotnet",
@@ -197,9 +195,7 @@
       "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
       "apiVersion": "2020-03-01",
       "name": "[concat(variables('cosmosDbAccountName'), '/botstate-db')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbAccountName'))]"
-      ],
+      "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts', variables('cosmosDbAccountName'))]"],
       "properties": {
         "resource": {
           "id": "botstate-db"
@@ -234,9 +230,7 @@
             ]
           },
           "partitionKey": {
-            "paths": [
-              "/id"
-            ],
+            "paths": ["/id"],
             "kind": "Hash"
           },
           "conflictResolutionPolicy": {
@@ -249,11 +243,11 @@
       "condition": "[parameters('useCosmosDb')]"
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2018-07-12",
       "type": "Microsoft.BotService/botServices",
       "name": "[parameters('botId')]",
       "location": "global",
-      "kind": "bot",
+      "kind": "azurebot",
       "sku": {
         "name": "[parameters('botSku')]"
       },
@@ -262,14 +256,13 @@
         "displayName": "[parameters('botId')]",
         "endpoint": "[variables('botEndpoint')]",
         "msaAppId": "[parameters('appId')]",
+        "openWithHint": "bfcomposer://",
         "developerAppInsightsApplicationId": null,
         "developerAppInsightKey": null,
         "publishingCredentials": null,
         "storageResourceId": null
       },
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-      ]
+      "dependsOn": ["[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"]
     },
     {
       "comments": "app insights",

--- a/extensions/samples/assets/shared/scripts/DeploymentTemplates/template-with-new-rg.json
+++ b/extensions/samples/assets/shared/scripts/DeploymentTemplates/template-with-new-rg.json
@@ -1,183 +1,182 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "groupLocation": {
-            "type": "string",
-            "metadata": {
-                "description": "Specifies the location of the Resource Group."
-            }
-        },
-        "groupName": {
-            "type": "string",
-            "metadata": {
-                "description": "Specifies the name of the Resource Group."
-            }
-        },
-        "appId": {
-            "type": "string",
-            "metadata": {
-                "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
-            }
-        },
-        "appSecret": {
-            "type": "string",
-            "metadata": {
-                "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
-            }
-        },
-        "botId": {
-            "type": "string",
-            "metadata": {
-                "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
-            }
-        },
-        "botSku": {
-            "type": "string",
-            "metadata": {
-                "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
-            }
-        },
-        "newAppServicePlanName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the App Service Plan."
-            }
-        },
-        "newAppServicePlanSku": {
-            "type": "object",
-            "defaultValue": {
-                "name": "S1",
-                "tier": "Standard",
-                "size": "S1",
-                "family": "S",
-                "capacity": 1
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "groupLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the location of the Resource Group."
+      }
+    },
+    "groupName": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifies the name of the Resource Group."
+      }
+    },
+    "appId": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+      }
+    },
+    "appSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+      }
+    },
+    "botId": {
+      "type": "string",
+      "metadata": {
+        "description": "The globally unique and immutable bot ID. Also used to configure the displayName of the bot, which is mutable."
+      }
+    },
+    "botSku": {
+      "type": "string",
+      "metadata": {
+        "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+      }
+    },
+    "newAppServicePlanName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the App Service Plan."
+      }
+    },
+    "newAppServicePlanSku": {
+      "type": "object",
+      "defaultValue": {
+        "name": "S1",
+        "tier": "Standard",
+        "size": "S1",
+        "family": "S",
+        "capacity": 1
+      },
+      "metadata": {
+        "description": "The SKU of the App Service Plan. Defaults to Standard values."
+      }
+    },
+    "newAppServicePlanLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "The location of the App Service Plan. Defaults to \"westus\"."
+      }
+    },
+    "newWebAppName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
+      }
+    }
+  },
+  "variables": {
+    "appServicePlanName": "[parameters('newAppServicePlanName')]",
+    "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
+    "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
+    "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
+    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+    "resourceGroupId": "[concat(subscription().id, '/resourceGroups/', parameters('groupName'))]"
+  },
+  "resources": [
+    {
+      "name": "[parameters('groupName')]",
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2018-05-01",
+      "location": "[parameters('groupLocation')]",
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2018-05-01",
+      "name": "storageDeployment",
+      "resourceGroup": "[parameters('groupName')]",
+      "dependsOn": ["[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {},
+          "variables": {},
+          "resources": [
+            {
+              "comments": "Create a new App Service Plan",
+              "type": "Microsoft.Web/serverfarms",
+              "name": "[variables('appServicePlanName')]",
+              "apiVersion": "2018-02-01",
+              "location": "[variables('resourcesLocation')]",
+              "sku": "[parameters('newAppServicePlanSku')]",
+              "properties": {
+                "name": "[variables('appServicePlanName')]"
+              }
             },
-            "metadata": {
-                "description": "The SKU of the App Service Plan. Defaults to Standard values."
-            }
-        },
-        "newAppServicePlanLocation": {
-            "type": "string",
-            "metadata": {
-                "description": "The location of the App Service Plan. Defaults to \"westus\"."
-            }
-        },
-        "newWebAppName": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The globally unique name of the Web App. Defaults to the value passed in for \"botId\"."
-            }
-        }
-    },
-    "variables": {
-        "appServicePlanName": "[parameters('newAppServicePlanName')]",
-        "resourcesLocation": "[parameters('newAppServicePlanLocation')]",
-        "webAppName": "[if(empty(parameters('newWebAppName')), parameters('botId'), parameters('newWebAppName'))]",
-        "siteHost": "[concat(variables('webAppName'), '.azurewebsites.net')]",
-        "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]"
-    },
-    "resources": [
-        {
-            "name": "[parameters('groupName')]",
-            "type": "Microsoft.Resources/resourceGroups",
-            "apiVersion": "2018-05-01",
-            "location": "[parameters('groupLocation')]",
-            "properties": {
-            }
-        },
-        {
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2018-05-01",
-            "name": "storageDeployment",
-            "resourceGroup": "[parameters('groupName')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Resources/resourceGroups/', parameters('groupName'))]"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {},
-                    "variables": {},
-                    "resources": [
-                        {
-                            "comments": "Create a new App Service Plan",
-                            "type": "Microsoft.Web/serverfarms",
-                            "name": "[variables('appServicePlanName')]",
-                            "apiVersion": "2018-02-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "sku": "[parameters('newAppServicePlanSku')]",
-                            "properties": {
-                                "name": "[variables('appServicePlanName')]"
-                            }
-                        },
-                        {
-                            "comments": "Create a Web App using the new App Service Plan",
-                            "type": "Microsoft.Web/sites",
-                            "apiVersion": "2015-08-01",
-                            "location": "[variables('resourcesLocation')]",
-                            "kind": "app",
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
-                            ],
-                            "name": "[variables('webAppName')]",
-                            "properties": {
-                                "name": "[variables('webAppName')]",
-                                "serverFarmId": "[variables('appServicePlanName')]",
-                                "siteConfig": {
-                                    "appSettings": [
-                                        {
-                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "10.14.1"
-                                        },
-                                        {
-                                            "name": "MicrosoftAppId",
-                                            "value": "[parameters('appId')]"
-                                        },
-                                        {
-                                            "name": "MicrosoftAppPassword",
-                                            "value": "[parameters('appSecret')]"
-                                        }
-                                    ],
-                                    "cors": {
-                                        "allowedOrigins": [
-                                            "https://botservice.hosting.portal.azure.net",
-                                            "https://hosting.onecloud.azure-test.net/"
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "apiVersion": "2017-12-01",
-                            "type": "Microsoft.BotService/botServices",
-                            "name": "[parameters('botId')]",
-                            "location": "global",
-                            "kind": "bot",
-                            "sku": {
-                                "name": "[parameters('botSku')]"
-                            },
-                            "properties": {
-                                "name": "[parameters('botId')]",
-                                "displayName": "[parameters('botId')]",
-                                "endpoint": "[variables('botEndpoint')]",
-                                "msaAppId": "[parameters('appId')]",
-                                "developerAppInsightsApplicationId": null,
-                                "developerAppInsightKey": null,
-                                "publishingCredentials": null,
-                                "storageResourceId": null
-                            },
-                            "dependsOn": [
-                                "[resourceId('Microsoft.Web/sites/', variables('webAppName'))]"
-                            ]
-                        }
-                    ],
-                    "outputs": {}
+            {
+              "comments": "Create a Web App using the new App Service Plan",
+              "type": "Microsoft.Web/sites",
+              "apiVersion": "2015-08-01",
+              "location": "[variables('resourcesLocation')]",
+              "kind": "app",
+              "dependsOn": [
+                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/serverfarms/', variables('appServicePlanName'))]"
+              ],
+              "name": "[variables('webAppName')]",
+              "properties": {
+                "name": "[variables('webAppName')]",
+                "serverFarmId": "[variables('appServicePlanName')]",
+                "siteConfig": {
+                  "appSettings": [
+                    {
+                      "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                      "value": "10.14.1"
+                    },
+                    {
+                      "name": "MicrosoftAppId",
+                      "value": "[parameters('appId')]"
+                    },
+                    {
+                      "name": "MicrosoftAppPassword",
+                      "value": "[parameters('appSecret')]"
+                    }
+                  ],
+                  "cors": {
+                    "allowedOrigins": [
+                      "https://botservice.hosting.portal.azure.net",
+                      "https://hosting.onecloud.azure-test.net/"
+                    ]
+                  }
                 }
+              }
+            },
+            {
+              "apiVersion": "2018-07-12",
+              "type": "Microsoft.BotService/botServices",
+              "name": "[parameters('botId')]",
+              "location": "global",
+              "kind": "azurebot",
+              "sku": {
+                "name": "[parameters('botSku')]"
+              },
+              "properties": {
+                "name": "[parameters('botId')]",
+                "displayName": "[parameters('botId')]",
+                "endpoint": "[variables('botEndpoint')]",
+                "msaAppId": "[parameters('appId')]",
+                "openWithHint": "bfcomposer://",
+                "developerAppInsightsApplicationId": null,
+                "developerAppInsightKey": null,
+                "publishingCredentials": null,
+                "storageResourceId": null
+              },
+              "dependsOn": [
+                "[concat(variables('resourceGroupId'), '/providers/Microsoft.Web/sites/', variables('webAppName'))]"
+              ]
             }
+          ],
+          "outputs": {}
         }
-    ]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Description
This PR updates the ARM templates to use AzureBot instead of Bot Channel Registration to create resources. The changes include:
- _ResourceGroupId_ variable added in _template-with-new-rg_ template.
- _WebAppService_ resource updated in _template-with-new-rg_ template.
- _BotService_ resource updated in _template-wit-new-rg_ and _funcion-template-with-preexisting-rg_ templates.

## Task Item
Fixes # 8787
#minor

## Screenshots
NodeJS EmptyBot working as expected using the _template-with-new-rg_ template.
<img width="757" alt="image" src="https://user-images.githubusercontent.com/64815358/176940673-23acfa43-e692-4df1-b3f0-2e2d08c83d95.png">

C# CoreBot working as expected using the _template-with-new-rg_ template.
<img width="643" alt="image" src="https://user-images.githubusercontent.com/64815358/176941463-037a68be-c0f5-4299-a04e-7521470bb50d.png">

Function EmptyBot working as expected using the _template-with-preexisting-rg_ template.
<img width="640" alt="image" src="https://user-images.githubusercontent.com/64815358/176941029-07e016d3-b011-4ef2-b388-e22a8b1a3fd7.png">





