### PR TITLE
fix: [#9204] Listed error gives link with incorrect label "Settings" instead of "Configure"

### DIFF
--- a/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
+++ b/Composer/packages/client/src/components/ProjectTree/treeItem.tsx
@@ -373,7 +373,7 @@ const DiagnosticIcons = (props: {
         {errors.map((item) => {
           let linkText = item.source;
           if (item.source === 'appsettings.json') {
-            linkText = 'Fix in bot settings';
+            linkText = 'Fix in Configure your bot';
           }
           return (
             <div key={item.message} css={diagnosticLink}>

--- a/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticType.ts
+++ b/Composer/packages/client/src/pages/design/DebugPanel/TabExtensions/DiagnosticsTab/DiagnosticType.ts
@@ -211,7 +211,7 @@ export class SettingDiagnostic extends DiagnosticInfo {
     super(rootProjectId, projectId, id, location, diagnostic);
     this.message = `${replaceDialogDiagnosticLabel(diagnostic.path)} ${diagnostic.message}`;
     this.dialogPath = diagnostic.path;
-    this.friendlyLocationBreadcrumbItems = ['Settings'];
+    this.friendlyLocationBreadcrumbItems = ['Configure'];
   }
   getUrl = (hash?: string) => {
     return createBotSettingUrl(this.rootProjectId, this.projectId, hash);


### PR DESCRIPTION
## Description
This PR updates the labels of the settings links in the error panels. They were changed to match the name of the 'Configure' menu. 
It changes: 
- "Settings" for "Configure".
- "Fix in bot settings" for "Fix in Configure your bot".

## Task Item
Fixes # 9204
#minor

## Screenshots
These images show the before and after of the labels.
![image](https://user-images.githubusercontent.com/44245136/176943025-6e9bfa7a-f8b9-4cd4-961d-c7a34a63a717.png)
![image](https://user-images.githubusercontent.com/44245136/176943115-b9097348-58e9-4cc9-adcf-01228a982aa3.png)