### PR TITLE
fix: [#7532] Publishing page loses information on reloading the bot

### DIFF
--- a/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/publisher.ts
@@ -102,12 +102,6 @@ export const publisherDispatcher = () => {
     const { set, snapshot } = callbackHelpers;
     const { endpointURL, status, port } = data;
 
-    // remove job id in publish storage if published
-    if (status === PUBLISH_SUCCESS || status === PUBLISH_FAILED) {
-      const publishJobIds = publishStorage.get('jobIds') || {};
-      delete publishJobIds[`${projectId}-${target.name}`];
-      publishStorage.set('jobIds', publishJobIds);
-    }
     // the action below only applies to when a bot is being started using the "start bot" button
     // a check should be added to this that ensures this ONLY applies to the "default" profile.
     if (target.name === defaultPublishConfig.name) {


### PR DESCRIPTION
## Description
This PR prevents a bot's publishing history from being lost when reloading the page or switching between bots.
Now, the _jobId_ isn't removed from publish storage when the bot is published.

## Task Item
Fixes # 7532
#minor

## Screenshots
This screenshot shows the last publish information after reload the page.
<img width="950" alt="image" src="https://user-images.githubusercontent.com/64815358/179283134-70537111-60cd-4119-ab4e-c36825fd8d24.png">

