### PR TITLE
fix: [#9151] LG for 'choices' field in multi choice input results in Warning

### DIFF
--- a/Composer/packages/lib/indexers/__tests__/validations/expressionValidation.test.ts
+++ b/Composer/packages/lib/indexers/__tests__/validations/expressionValidation.test.ts
@@ -69,4 +69,14 @@ describe('validate expression', () => {
     const result = checkExpression("=concat('test', '1')", true, [ReturnType.String]);
     expect(result).toBe(24);
   });
+
+  it('use LG expressions will not throw error', () => {
+    try {
+      checkExpression('${LGChoiceOptions()}', true, [ReturnType.Number]);
+    } catch (error) {
+      expect(error.message).toBe(
+        "LGChoiceOptions does not have an evaluator, it's not a built-in function or a custom function."
+      );
+    }
+  });
 });

--- a/Composer/packages/lib/indexers/src/validations/expressionValidation/validation.ts
+++ b/Composer/packages/lib/indexers/src/validations/expressionValidation/validation.ts
@@ -20,6 +20,27 @@ export const addReturnType = (currentType: number, newType: number) => {
   return currentType | newType;
 };
 
+export const trimExpression = (expression: string): string => {
+  let result = expression.trim();
+  if (result.startsWith('=')) {
+    result = result.substring(1);
+  }
+
+  result = result.trim();
+
+  if (result.startsWith('$')) {
+    result = result.substring(1);
+  }
+
+  result = result.trim();
+
+  if (result.startsWith('{') && result.endsWith('}')) {
+    result = result.substring(1, result.length - 1);
+  }
+
+  return result.trim();
+};
+
 export const checkStringExpression = (exp: string, isStringType: boolean): number => {
   const origin = exp.trim();
   const containsEqual = origin.startsWith('=');
@@ -28,7 +49,9 @@ export const checkStringExpression = (exp: string, isStringType: boolean): numbe
     return ReturnType.String;
   }
 
-  return Expression.parse(containsEqual ? origin.substring(1) : origin).returnType;
+  const trimmedOrigin = trimExpression(origin);
+
+  return Expression.parse(trimmedOrigin).returnType;
 };
 
 export const checkExpression = (exp: any, required: boolean, types: number[]): number => {

--- a/Composer/packages/lib/indexers/src/validations/expressionValidation/validation.ts
+++ b/Composer/packages/lib/indexers/src/validations/expressionValidation/validation.ts
@@ -23,22 +23,18 @@ export const addReturnType = (currentType: number, newType: number) => {
 export const trimExpression = (expression: string): string => {
   let result = expression.trim();
   if (result.startsWith('=')) {
-    result = result.substring(1);
+    result = result.substring(1).trim();
   }
-
-  result = result.trim();
 
   if (result.startsWith('$')) {
-    result = result.substring(1);
+    result = result.substring(1).trim();
   }
-
-  result = result.trim();
 
   if (result.startsWith('{') && result.endsWith('}')) {
-    result = result.substring(1, result.length - 1);
+    result = result.substring(1, result.length - 1).trim();
   }
 
-  return result.trim();
+  return result;
 };
 
 export const checkStringExpression = (exp: string, isStringType: boolean): number => {


### PR DESCRIPTION
## Description

This PR fixes the validation of LG expressions to avoid showing a warning when LG expressions are used.
A `trimExpression` function was added to remove the `${}` characters of the expression allowing it to be correctly parsed.
It also adds a unit test to cover this new function.

## Task Item
Fixes # 9151
#minor

## Screenshots
These images show the warning shown before and the LG expression being properly validated after.

BEFORE
![image](https://user-images.githubusercontent.com/44245136/181610581-3f498f7d-6ec6-4e6e-820d-e8b31e32e138.png)
AFTER
![image](https://user-images.githubusercontent.com/44245136/181610714-a0c69888-8190-4fd8-8c7e-12d9de0ad170.png)