### PR TITLE
fix: [#9331] Substring function contains wrong tooltip information

### DIFF
--- a/Composer/packages/tools/built-in-functions/src/builtInFunctionsMap.ts
+++ b/Composer/packages/tools/built-in-functions/src/builtInFunctionsMap.ts
@@ -253,7 +253,7 @@ export const buildInFunctionsMap: Map<string, FunctionEntity> = new Map<string, 
     new FunctionEntity(
       ['text: string', 'startIndex: number', 'length?: number'],
       ReturnType.String,
-      'Returns characters from a string. Substring(sourceString, startPos, endPos). startPos cannot be less than 0. endPos greater than source strings length will be taken as the max length of the string.'
+      'Returns characters from a string. Substring(sourceString, startPos, length). startPos cannot be less than 0. A length greater than source strings length will be taken as the max length of the string.'
     ),
   ],
   [


### PR DESCRIPTION
## Description

This PR fixes the tooltip description of the **_Substring_** function to reflect the current parameters.

_Note: we tested the case reported in the issue:_

> a length from the startPos that surpasses the length of the string will generate an out of range exception, not be taken as the max length of the string.

_but the exception was not thrown so we didn't update that part of the description._

## Task Item

Fixes # 9331
#minor

## Screenshots

These images show the before and after.
![image](https://user-images.githubusercontent.com/44245136/184441221-2dd9b632-ef79-4f6e-8a85-7ca0b9911b29.png)