### PR TITLE
fix: [#9327] Bot Composer crashes when using Throw Exception activity

### DIFF
--- a/Composer/packages/ui-plugins/composer/src/defaultFlowSchema.ts
+++ b/Composer/packages/ui-plugins/composer/src/defaultFlowSchema.ts
@@ -221,7 +221,7 @@ export const DefaultFlowSchema: FlowUISchema = {
     widget: 'ActionCard',
     body: {
       widget: 'PropertyDescription',
-      property: '=coalesce(action.errorValue, "?")',
+      property: '=coalesce(string(action.errorValue), "?")',
       description: '= ErrorValue',
     },
   },


### PR DESCRIPTION
Fixes # 9327

## Description
This PR fixes an issue when creating a `Debugging options => Throw exception` event inside a trigger, Composer freezes and the UI stops working for the trigger that has the failed event.
Furthermore, this is caused by React, since it can't render `objects` (`{ "action": "hello" } | [ { "action": "hello" } ]`) to the UI.

## Specific Changes
- Adds the [string AdaptiveExpressions built-in](https://docs.microsoft.com/en-us/azure/bot-service/adaptive-expressions/adaptive-expressions-prebuilt-functions?view=azure-bot-service-4.0#string) function to the `property` of the `ThrowException` `PropertyDescription` component, casting any element that comes in the `errorValue` field (`string, number, boolean, object, array, array of objects, etc`).

## Testing
The following image shows the tested samples working as expected without freezing the UI.
![image](https://user-images.githubusercontent.com/62260472/185623962-c7bee673-967b-47c0-a87b-78ec370ed984.png)

