### PR TITLE
fix: [#8890] Bot won't publish to Linux, Windows works fine

### DIFF
--- a/Composer/packages/server/src/externalContentProvider/azureBotServiceProvider.ts
+++ b/Composer/packages/server/src/externalContentProvider/azureBotServiceProvider.ts
@@ -74,7 +74,7 @@ export class AzureBotServiceProvider extends ExternalContentProvider<AzureBotSer
       type: 'azurePublish',
       configuration: JSON.stringify({
         hostname: '',
-        runtimeIdentifier: 'win-x64',
+        runtimeIdentifier: this.metadata.runtimeIdentifier ?? 'win-x64',
         settings: {
           MicrosoftAppId: appId,
           MicrosoftAppPassword: appPwd,

--- a/extensions/azurePublish/src/node/index.ts
+++ b/extensions/azurePublish/src/node/index.ts
@@ -305,6 +305,13 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
       }
       const currentSettings = currentProfile?.settings;
 
+      let runtimeIdentifier = 'win-x64';
+      if (currentProfile?.runtimeIdentifier) {
+        runtimeIdentifier = currentProfile?.runtimeIdentifier;
+      } else if (provisionConfig.appServiceOperatingSystem === 'linux') {
+        runtimeIdentifier = 'linux-x64';
+      }
+
       const publishProfile = {
         name: currentProfile?.name ?? provisionConfig.hostname,
         environment: currentProfile?.environment ?? 'composer',
@@ -316,7 +323,7 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
         luisResource: provisionResults.luisPrediction
           ? `${provisionConfig.hostname}-luis`
           : currentProfile?.luisResource,
-        runtimeIdentifier: currentProfile?.runtimeIdentifier ?? 'win-x64',
+        runtimeIdentifier: runtimeIdentifier,
         region: provisionConfig.location,
         appServiceOperatingSystem:
           provisionConfig.appServiceOperatingSystem ?? currentProfile?.appServiceOperatingSystem,


### PR DESCRIPTION
Fixes # 8890
#minor

## Description
This PR fixes an issue with publishing Linux bots to Azure that caused the publishing process never to finish.
This behavior occurred because the deployment process used a property (which the Linux bots don't include) to determine if the deployment process had finished.
Also, it fixes two configuration issues that were causing the bot deployed to Linux not to work, the _runtimeIdentifier_ that was always set as _win-x64_, and the _Stack settings_ that need to be set in Linux bots.

## Specific Changes
- Adds new statusEnum const to map the bot's status.
- Updates `azureBotServiceProvider.ts` and `azurePublish/src/node/index.ts` to use the profile's _runtimeIdentifier_ property.
- Updates `azurePublish/src/node/deploy.ts` adding a step to set up the _linuxFxVersion_ in case a .NET bot is being deployed to a Linux environment.

## Testing
These screenshots show the Linux bot successfully deployed and working in Azure.
![image](https://user-images.githubusercontent.com/44245136/191782174-547a45c6-d475-4161-a8fa-d35c16d12425.png)
