### PR TITLE
test: Broken link in UI: Configure/Connections/External connections/see documentation-erqui

### DIFF
--- a/Composer/packages/client/src/pages/botProject/adapters/AdapterSection.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/AdapterSection.tsx
@@ -72,7 +72,7 @@ const AdapterSection = ({ projectId, scrollToSectionId }: Props) => {
               a2: ({ children }) => (
                 <Link
                   key="package-adapter-settings-page-learn-more"
-                  href={'https://aka.ms/composer-packagmanageraddconnection-learnmore'}
+                  href={'https://docs.microsoft.com/en-us/composer/how-to-manage-packages?tabs=dotnet'}
                   target="_blank"
                 >
                   {children}

--- a/Composer/packages/client/src/pages/botProject/adapters/AdapterSection.tsx
+++ b/Composer/packages/client/src/pages/botProject/adapters/AdapterSection.tsx
@@ -72,7 +72,9 @@ const AdapterSection = ({ projectId, scrollToSectionId }: Props) => {
               a2: ({ children }) => (
                 <Link
                   key="package-adapter-settings-page-learn-more"
-                  href={'https://docs.microsoft.com/en-us/composer/how-to-manage-packages?tabs=dotnet'}
+                  href={
+                    'https://docs.microsoft.com/en-us/composer/how-to-manage-packages?tabs=dotnet#connect-to-package-feeds'
+                  }
                   target="_blank"
                 >
                   {children}


### PR DESCRIPTION
Description
This PR fixed the "Add external connections" link which was returning a 404 error by replacing it with the link to the corresponding MS document.

Task Item
#minor

Screenshots
This image shows the link working.