### PR TITLE
fix: [#9384] Node Core Bot With Language failed to deploy to Linux

### DIFF
--- a/Composer/packages/server/src/externalContentProvider/azureBotServiceProvider.ts
+++ b/Composer/packages/server/src/externalContentProvider/azureBotServiceProvider.ts
@@ -74,7 +74,7 @@ export class AzureBotServiceProvider extends ExternalContentProvider<AzureBotSer
       type: 'azurePublish',
       configuration: JSON.stringify({
         hostname: '',
-        runtimeIdentifier: 'win-x64',
+        runtimeIdentifier: this.metadata.runtimeIdentifier ?? 'win-x64',
         settings: {
           MicrosoftAppId: appId,
           MicrosoftAppPassword: appPwd,

--- a/extensions/azurePublish/src/node/deploy.ts
+++ b/extensions/azurePublish/src/node/deploy.ts
@@ -172,15 +172,26 @@ export class BotProjectDeploy {
       const profile = settings.publishTargets.find((p) => p.name === profileName);
       const configuration = JSON.parse(profile.configuration);
 
-      if (settings.runtime.command.includes('dotnet') && configuration.appServiceOperatingSystem === 'linux') {
-        await this.updateBotSettings(
-          this.accessToken,
-          name,
-          environment,
-          hostname,
-          absSettings.subscriptionId,
-          absSettings.resourceGroup
-        );
+      if (configuration.appServiceOperatingSystem === 'linux') {
+        let linuxFxVersion = '';
+
+        if (settings.runtime.command.includes('dotnet')) {
+          linuxFxVersion = 'DOTNETCORE|3.1';
+        }
+        if (settings.runtime.command.includes('npm')) {
+          linuxFxVersion = 'NODE|14-lts';
+        }
+        if (linuxFxVersion.length > 0) {
+          await this.updateBotSettings(
+            this.accessToken,
+            name,
+            environment,
+            hostname,
+            absSettings.subscriptionId,
+            absSettings.resourceGroup,
+            linuxFxVersion
+          );
+        }
       }
     } catch (error) {
       this.logger({
@@ -359,13 +370,16 @@ export class BotProjectDeploy {
     env: string,
     hostname: string,
     subscriptionId: string,
-    resourceGroup: string
+    resourceGroup: string,
+    linuxFxVersion: string
   ) {
     try {
       const updateEndpoint = this.buildUpdateEndpoint(hostname, name, env, subscriptionId, resourceGroup);
       const response = await axios.put(
         updateEndpoint,
-        { properties: { linuxFxVersion: 'DOTNETCORE|3.1' } },
+        {
+          properties: { linuxFxVersion: linuxFxVersion },
+        },
         { headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' } }
       );
 

--- a/extensions/azurePublish/src/node/index.ts
+++ b/extensions/azurePublish/src/node/index.ts
@@ -305,6 +305,13 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
       }
       const currentSettings = currentProfile?.settings;
 
+      let runtimeIdentifier = 'win-x64';
+      if (currentProfile?.runtimeIdentifier) {
+        runtimeIdentifier = currentProfile?.runtimeIdentifier;
+      } else if (provisionConfig.appServiceOperatingSystem === 'linux') {
+        runtimeIdentifier = 'linux-x64';
+      }
+
       const publishProfile = {
         name: currentProfile?.name ?? provisionConfig.hostname,
         environment: currentProfile?.environment ?? 'composer',
@@ -316,7 +323,7 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
         luisResource: provisionResults.luisPrediction
           ? `${provisionConfig.hostname}-luis`
           : currentProfile?.luisResource,
-        runtimeIdentifier: currentProfile?.runtimeIdentifier ?? 'win-x64',
+        runtimeIdentifier: runtimeIdentifier,
         region: provisionConfig.location,
         appServiceOperatingSystem:
           provisionConfig.appServiceOperatingSystem ?? currentProfile?.appServiceOperatingSystem,


### PR DESCRIPTION
Fixes # 9384
#minor

## Description
This PR fixes the issues that prevent Node bots to be successfully deployed on a Linux environment.
It depends on the fixes made in PR#XXXX for .NET bots and includes a condition to set the **_linuxFxVersion_** property with the proper value for Node bots.

## Specific Changes
- Updates condition in `azurePublish/src/node/deploy.ts` to set up the _linuxFxVersion_ property with 'NODE|14-lts' in case a Node bot is being deployed to a Linux environment.

## Testing
These screenshots show the Linux bot successfully deployed and working in Azure.
![image](https://user-images.githubusercontent.com/44245136/193037788-bf869134-fd35-4b8d-8247-69a67dc65698.png)