### PR TITLE
fix: PR test - yarn-berry files updated

### DIFF
--- a/Composer/packages/tools/built-in-functions/src/builtInFunctionsMap.ts
+++ b/Composer/packages/tools/built-in-functions/src/builtInFunctionsMap.ts
@@ -253,7 +253,7 @@ export const buildInFunctionsMap: Map<string, FunctionEntity> = new Map<string, 
     new FunctionEntity(
       ['text: string', 'startIndex: number', 'length?: number'],
       ReturnType.String,
-      'Returns characters from a string. Substring(sourceString, startPos, length). startPos cannot be less than 0. A new length greater than source strings length will be taken as the max length of the string.'
+      'Returns characters from a string. Substring(sourceString, startPos, length). startPos cannot be less than 0. A new length v2 greater than source strings length will be taken as the max length of the string.'
     ),
   ],
   [


### PR DESCRIPTION
## Description

**TEST***

This PR fixes the tooltip description of the **_Substring_** function to reflect the current parameters.

_Note: we tested the case reported in the issue:_

> a length from the startPos that surpasses the length of the string will generate an out of range exception, not be taken as the max length of the string.

_but the exception was not thrown so we didn't update that part of the description._

## Task Item

Fixes # 9331
#minor

## Screenshots