### PR TITLE
fix: [#9346] Override global Window internal symbol property for the Monaco Editor

### DIFF
--- a/Composer/packages/lib/code-editor/src/LuEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/LuEditor.tsx
@@ -94,7 +94,6 @@ const defaultLUServer = {
 
 declare global {
   interface Window {
-    monacoServiceInstance: MonacoServices;
     monacoLUEditorInstance: MonacoLanguageClient;
   }
 }
@@ -187,9 +186,7 @@ const LuEditor: React.FC<LULSPEditorProps> = (props) => {
 
     if (!editor) return;
 
-    if (!window.monacoServiceInstance) {
-      window.monacoServiceInstance = MonacoServices.install(editor as any);
-    }
+    MonacoServices.install(editor as any);
 
     const uri = get(editor.getModel(), 'uri._formatted', '');
 

--- a/Composer/packages/lib/code-editor/src/lg/LgCodeEditor.tsx
+++ b/Composer/packages/lib/code-editor/src/lg/LgCodeEditor.tsx
@@ -76,7 +76,6 @@ const defaultLGServer = {
 
 declare global {
   interface Window {
-    monacoServiceInstance: MonacoServices;
     monacoLGEditorInstance: MonacoLanguageClient;
   }
 }
@@ -128,9 +127,7 @@ export const LgCodeEditor = (props: LgCodeEditorProps) => {
 
     if (!editor) return;
 
-    if (!window.monacoServiceInstance) {
-      window.monacoServiceInstance = MonacoServices.install(editor as any);
-    }
+    MonacoServices.install(editor as any);
 
     const uri = get(editor.getModel(), 'uri._formatted', '');
 


### PR DESCRIPTION
Addresses # 9346

## Description
This PR solves part of an issue where the Monaco Editor was generating a memory leak when the Authoring Canvas page is rendered multiple times.
> **Note:** This implementation will show an error message into the DevTools console saying that the "language Client services has been overridden", this error does not affect Composer functionality as it is an informative message.

## Specific Changes
- Remove use of global Window property object when installing Monaco Services.

## Testing
The following image shows the memory leak and the console error message.
![imagen](https://user-images.githubusercontent.com/62260472/200400850-625c2635-9cb3-4d20-a9f1-39f2fa13aad0.png)
