### PR TITLE
fix: [#9346] Remove new line symbol from LGWidget

### DIFF
--- a/Composer/packages/ui-plugins/lg/src/LgWidget/useLgTemplate.ts
+++ b/Composer/packages/ui-plugins/lg/src/LgWidget/useLgTemplate.ts
@@ -41,7 +41,7 @@ const getLgTemplateTextData = (
                   .filter((s) => s.kind === 'variation')
                   .map((s) => s.value);
                 if (variations.length) {
-                  acc[responseType] = { value: variations[0].replace(/\r?\n/g, '↵'), moreCount: variations.length - 1 };
+                  acc[responseType] = { value: variations[0], moreCount: variations.length - 1 };
                 }
               }
             } else {

--- a/Composer/packages/ui-plugins/lg/src/__test__/useLgTemplate.test.tsx
+++ b/Composer/packages/ui-plugins/lg/src/__test__/useLgTemplate.test.tsx
@@ -131,7 +131,7 @@ sp1.1\`\`\`
 
 const expectedResult = {
   Text: { value: 'This is a somewhat long text we are trying to check', moreCount: 1 },
-  Speak: { value: 'sp1↵sp1.1', moreCount: 2 },
+  Speak: { value: 'sp1\nsp1.1', moreCount: 2 },
   Attachments: {
     value:
       "> To learn more Adaptive Cards format, read the documentation at\n> https://docs.microsoft.com/en-us/adaptive-cards/getting-started/bots\n- ```${json({\n  $schema: 'http://adaptivecards.io/schemas/adaptive-card.json',\n  version: '1.2',\n  type: 'AdaptiveCard',\n  body: [\n    {\n      type: 'TextBlock',\n      text: 'default text',\n      weight: 'bolder',\n      isSubtle: false,\n    },\n  ],\n})}```",


### PR DESCRIPTION
Addresses # 9346
#minor

## Description
This PR solves part of an issue when rendering the [LGWidget](https://github.com/microsoft/BotFramework-Composer/blob/3f184ebe6bf491aa9e61282572d8b33e297d14da/Composer/packages/ui-plugins/lg/src/LgWidget/LgWidget.tsx) component (internal process to recognize language generation texts) to the Authoring Canvas UI.
Language generation texts that have multiple lines, new lines are being replaced with the ↵ [symbol](https://www.compart.com/en/unicode/U+21B5) concatenating the texts into a single one causing the memory to increase when interacting in Composer.
By removing the new line symbol, and just leave the text as is (with the new lines only) reduced the amount of memory storage used.


## Specific Changes
- Removes the ↵ symbol from the [useLgTemplate.ts](https://github.com/microsoft/BotFramework-Composer/blob/main/Composer/packages/ui-plugins/lg/src/LgWidget/useLgTemplate.ts#L44) file.
- Updates unit test, removing use of the ↵ symbol.

## Testing
The following image shows the before and after the applied fix, how the memory usage and the Authoring Canvas behaves.
![image](https://user-images.githubusercontent.com/62260472/204359559-177e3653-3f3e-4e52-b1b2-a4ce453699a0.png)