### PR TITLE
fix: [#9441] Multi-line SSML causes escaping issues

### DIFF
--- a/Composer/packages/lib/code-editor/src/lg/hooks/useStringArray.ts
+++ b/Composer/packages/lib/code-editor/src/lg/hooks/useStringArray.ts
@@ -30,6 +30,13 @@ const getInitialItems = <T extends ArrayBasedStructuredResponseItem>(
 const fixMultilineItems = (items: TemplateBodyItem[]) => {
   return items.map((item) => {
     if (item.kind === 'variation' && /\r?\n/g.test(item.value)) {
+      // if it's an SSML tag, remove the line breaks.
+      if (/^<speak/g.test(item.value.trim())) {
+        return {
+          ...item,
+          value: item.value.replace(/[\r\n]+/g, ''),
+        };
+      }
       return {
         ...item,
         // Escape all un-escaped -

--- a/extensions/azurePublish/yarn-berry.lock
+++ b/extensions/azurePublish/yarn-berry.lock
@@ -1879,7 +1879,7 @@ __metadata:
 
 "@bfc/code-editor@file:../../Composer/packages/lib/code-editor::locator=azurePublish%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/code-editor@file:../../Composer/packages/lib/code-editor#../../Composer/packages/lib/code-editor::hash=cf4a8a&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/code-editor@file:../../Composer/packages/lib/code-editor#../../Composer/packages/lib/code-editor::hash=10c7ff&locator=azurePublish%40workspace%3A."
   dependencies:
     "@emotion/react": ^11.1.3
     "@emotion/styled": ^11.1.3
@@ -1902,7 +1902,7 @@ __metadata:
     "@bfc/ui-shared": "*"
     react: 16.13.1
     react-dom: 16.13.1
-  checksum: f3773eb308e7e1d6db3d13220510b48c7659febca2441213fbc3deeff35abddf559f8cababdea58a5630ae214124f82299ce1d86fe89a5196369adc9ab9234f7
+  checksum: a287c0e36aae4a0ddca330161b09529a477eb74437731e3065058b237b9b61858cf398bbf208be06d9868e3a505a11b588c0479f154a9463793ee66b81862de4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR fixes the escaping issue happening when adding an SSML tag as the Speak value for a "Send a response" node.
The [_fixMultilineItems_](https://github.com/microsoft/BotFramework-Composer/blob/main/Composer/packages/lib/code-editor/src/lg/hooks/useStringArray.ts#L30) function in _useStringArray_ was treating the tag as a multiline variation. We added a condition to remove the line breaks if the variation includes SSML content.

## Task Item
Fixes # 9441
#minor

## Screenshots
These images show the escaping made before and no escaping applied after the changes.
![image](https://user-images.githubusercontent.com/44245136/206279010-2ec41977-2e28-418f-8aa4-4a4851e76f85.png)
