### PR TITLE
fix: [#9439] Composer emits "input parameters" from dialog interface with external references instead of simple types; breaking PVA

### DIFF
--- a/Composer/packages/ui-plugins/schema-editor/src/__tests__/SchemaEditorField.test.tsx
+++ b/Composer/packages/ui-plugins/schema-editor/src/__tests__/SchemaEditorField.test.tsx
@@ -7,7 +7,6 @@ import { EditorExtension } from '@bfc/extension-client';
 import { render, fireEvent } from '@botframework-composer/test-utils';
 
 import { SchemaEditorField } from '../Fields/SchemaEditorField';
-import { SCHEMA_URI } from '../contants';
 
 const renderSchemaEditor = ({ updateDialogSchema = jest.fn() } = {}) => {
   const api: any = {
@@ -61,7 +60,7 @@ describe('Schema Editor', () => {
           properties: expect.objectContaining({
             propertyName: {
               title: 'Property Name',
-              $ref: `${SCHEMA_URI}#/definitions/valueExpression`,
+              type: 'string',
             },
           }),
         }),

--- a/Composer/packages/ui-plugins/schema-editor/src/uiOptions.ts
+++ b/Composer/packages/ui-plugins/schema-editor/src/uiOptions.ts
@@ -5,8 +5,6 @@ import { UIOptions } from '@bfc/extension-client';
 import formatMessage from 'format-message';
 import startCase from 'lodash/startCase';
 
-import { ValueRefField } from './Fields/ValueRefField';
-
 const objectSerializer = {
   get: (value) => value,
   set: (value) =>
@@ -25,15 +23,6 @@ export const uiOptions: UIOptions = {
         additionalProperties: {
           hidden: ['title'],
           order: ['type', 'description', '*'],
-          serializer: {
-            get: ({ $ref, ...rest }: any = {}) => ($ref ? { ...rest, type: $ref } : rest),
-            set: ({ type, ...rest }: any = {}) => (type ? { ...rest, $ref: type } : rest),
-          },
-          properties: {
-            type: {
-              field: ValueRefField,
-            },
-          },
         },
       },
     },


### PR DESCRIPTION
## Description

This PR updates the input parameters of the dialog to be simple types in the [uiOptions.ts](https://github.com/microsoft/BotFramework-Composer/blob/main/Composer/packages/ui-plugins/schema-editor/src/uiOptions.ts) class.
It also fixes a unit test to consider the new types.

## Task Item
Fixes # 9439
#minor

## Screenshots
These images show a Composer skill bot working with a Composer and a PVA root bots.
![image](https://user-images.githubusercontent.com/44245136/207953102-6d6d5914-3fb3-4702-a436-ad3b801758d7.png)
![image](https://user-images.githubusercontent.com/44245136/207953123-184881a8-d801-4ef8-80a7-6ac41d95bfc8.png)

