### PR TITLE
fix: [#9517][CSS] PRO | COMPOSER | In <dialogName>.triggers[0].actions[0]: Text: alwaysPrompt the return type does not match

### DIFF
--- a/Composer/packages/lib/indexers/src/validations/expressionValidation/index.ts
+++ b/Composer/packages/lib/indexers/src/validations/expressionValidation/index.ts
@@ -49,7 +49,7 @@ export const validateExpressions: ValidateFunc = (
     let errorMessage = '';
     let warningMessage = '';
     try {
-      const valueToValidate = cache?.[path] ? cache[path] : checkExpression(value, required, types)
+      const valueToValidate = cache?.[path] ? cache[path] : checkExpression(value, required, types);
       errorMessage = checkReturnType(valueToValidate, types);
       if (!errorMessage) {
         //First validate that the types of the value match and then store the type value in newCache using the path as key to avoid overwriting.

--- a/Composer/packages/lib/indexers/src/validations/expressionValidation/index.ts
+++ b/Composer/packages/lib/indexers/src/validations/expressionValidation/index.ts
@@ -49,10 +49,12 @@ export const validateExpressions: ValidateFunc = (
     let errorMessage = '';
     let warningMessage = '';
     try {
-      //the cacheKey adds the type of the value at the end, this allows a new indexing system to prevent the overwriting in cache
-      const cacheKey = types.length > 1 ? value : `${value}.${types[0]}`;
-      newCache[cacheKey] = cache?.[cacheKey] ? cache[cacheKey] : checkExpression(value, required, types);
-      errorMessage = checkReturnType(newCache[cacheKey], types);
+      const valueToValidate = cache?.[path] ? cache[path] : checkExpression(value, required, types)
+      errorMessage = checkReturnType(valueToValidate, types);
+      if (!errorMessage) {
+        //First validate that the types of the value match and then store the type value in newCache using the path as key to avoid overwriting.
+        newCache[path] = valueToValidate;
+      }
     } catch (error) {
       //change the missing custom function error to warning
       warningMessage = filterCustomFunctionError(error.message, customFunctions);

--- a/Composer/packages/lib/indexers/src/validations/expressionValidation/index.ts
+++ b/Composer/packages/lib/indexers/src/validations/expressionValidation/index.ts
@@ -49,8 +49,9 @@ export const validateExpressions: ValidateFunc = (
     let errorMessage = '';
     let warningMessage = '';
     try {
-      newCache[value] = cache?.[value] ? cache[value] : checkExpression(value, required, types);
-      errorMessage = checkReturnType(newCache[value], types);
+      const cacheKey = types.length > 1 ? value : `${value}.${types[0]}`;
+      newCache[cacheKey] = cache?.[cacheKey] ? cache[cacheKey] : checkExpression(value, required, types);
+      errorMessage = checkReturnType(newCache[cacheKey], types);
     } catch (error) {
       //change the missing custom function error to warning
       warningMessage = filterCustomFunctionError(error.message, customFunctions);

--- a/Composer/packages/lib/indexers/src/validations/expressionValidation/index.ts
+++ b/Composer/packages/lib/indexers/src/validations/expressionValidation/index.ts
@@ -49,6 +49,7 @@ export const validateExpressions: ValidateFunc = (
     let errorMessage = '';
     let warningMessage = '';
     try {
+      //the cacheKey adds the type of the value at the end, this allows a new indexing system to prevent the overwriting in cache
       const cacheKey = types.length > 1 ? value : `${value}.${types[0]}`;
       newCache[cacheKey] = cache?.[cacheKey] ? cache[cacheKey] : checkExpression(value, required, types);
       errorMessage = checkReturnType(newCache[cacheKey], types);

--- a/extensions/azurePublish/yarn-berry.lock
+++ b/extensions/azurePublish/yarn-berry.lock
@@ -1896,7 +1896,7 @@ __metadata:
 
 "@bfc/indexers@file:../../Composer/packages/lib/indexers::locator=azurePublish%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=07822c&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=4b3d72&locator=azurePublish%40workspace%3A."
   dependencies:
     "@microsoft/bf-lu": 4.15.0-dev.20210702.cbf708d
     adaptive-expressions: ^4.18.0
@@ -1905,7 +1905,7 @@ __metadata:
     tslib: 2.4.0
   peerDependencies:
     "@bfc/shared": "*"
-  checksum: e75d94610a3de51ff52b7ec165e028d9a9ebaceff8db361acbdacc83fdd8d15ee4320bf0771ddf7d163bcb295ed31523a0c3fa1e49bb68a68d4aebbce85b2470
+  checksum: 2e347f39395e735232d68d264714099b744004c7353b310f9fc56bf9c364bba818ecebca58738b3298c038eaf5d09c2c3f3adb768d8c8ea441797d7486ad27a1
   languageName: node
   linkType: hard
 

--- a/extensions/azurePublish/yarn-berry.lock
+++ b/extensions/azurePublish/yarn-berry.lock
@@ -1896,7 +1896,7 @@ __metadata:
 
 "@bfc/indexers@file:../../Composer/packages/lib/indexers::locator=azurePublish%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=99ba57&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=52caad&locator=azurePublish%40workspace%3A."
   dependencies:
     "@microsoft/bf-lu": 4.15.0-dev.20210702.cbf708d
     adaptive-expressions: ^4.18.0
@@ -1905,7 +1905,7 @@ __metadata:
     tslib: 2.4.0
   peerDependencies:
     "@bfc/shared": "*"
-  checksum: 5a2aab3716adf348a98496dd60f07dacb492f8d4e5e393b6cee28d0f39ae5291f5985c4e64f549dde184ec3d49a4a531c1963de19278b89497966fd2fce4373f
+  checksum: 1e0e72e94ee93ca43e97cf7d4a4bad2ac9bddd32308c4c596966c1fda9ae712812ba27c2f76f72efae37160d04d1a349fbe09bc889a3858e52e493b77f7e1a5a
   languageName: node
   linkType: hard
 

--- a/extensions/azurePublish/yarn-berry.lock
+++ b/extensions/azurePublish/yarn-berry.lock
@@ -1896,7 +1896,7 @@ __metadata:
 
 "@bfc/indexers@file:../../Composer/packages/lib/indexers::locator=azurePublish%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=4b3d72&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=99ba57&locator=azurePublish%40workspace%3A."
   dependencies:
     "@microsoft/bf-lu": 4.15.0-dev.20210702.cbf708d
     adaptive-expressions: ^4.18.0
@@ -1905,7 +1905,7 @@ __metadata:
     tslib: 2.4.0
   peerDependencies:
     "@bfc/shared": "*"
-  checksum: 2e347f39395e735232d68d264714099b744004c7353b310f9fc56bf9c364bba818ecebca58738b3298c038eaf5d09c2c3f3adb768d8c8ea441797d7486ad27a1
+  checksum: 5a2aab3716adf348a98496dd60f07dacb492f8d4e5e393b6cee28d0f39ae5291f5985c4e64f549dde184ec3d49a4a531c1963de19278b89497966fd2fce4373f
   languageName: node
   linkType: hard
 

--- a/extensions/azurePublish/yarn-berry.lock
+++ b/extensions/azurePublish/yarn-berry.lock
@@ -1896,7 +1896,7 @@ __metadata:
 
 "@bfc/indexers@file:../../Composer/packages/lib/indexers::locator=azurePublish%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=52caad&locator=azurePublish%40workspace%3A."
+  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=8e5fca&locator=azurePublish%40workspace%3A."
   dependencies:
     "@microsoft/bf-lu": 4.15.0-dev.20210702.cbf708d
     adaptive-expressions: ^4.18.0
@@ -1905,7 +1905,7 @@ __metadata:
     tslib: 2.4.0
   peerDependencies:
     "@bfc/shared": "*"
-  checksum: 1e0e72e94ee93ca43e97cf7d4a4bad2ac9bddd32308c4c596966c1fda9ae712812ba27c2f76f72efae37160d04d1a349fbe09bc889a3858e52e493b77f7e1a5a
+  checksum: 31d8a809464f7fa700f4baef1ace105d62f8586d249ad56f6b02edeb4cb5be4a97d4109e589fa8e331378f6e8616c7c976dba70b29c71fa7bc32138a73dda91b
   languageName: node
   linkType: hard
 

--- a/extensions/azurePublishNew/yarn-berry.lock
+++ b/extensions/azurePublishNew/yarn-berry.lock
@@ -1936,7 +1936,7 @@ __metadata:
 
 "@bfc/indexers@file:../../Composer/packages/lib/indexers::locator=azure-publish-new%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=52caad&locator=azure-publish-new%40workspace%3A."
+  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=8e5fca&locator=azure-publish-new%40workspace%3A."
   dependencies:
     "@microsoft/bf-lu": 4.15.0-dev.20210702.cbf708d
     adaptive-expressions: ^4.18.0
@@ -1945,7 +1945,7 @@ __metadata:
     tslib: 2.4.0
   peerDependencies:
     "@bfc/shared": "*"
-  checksum: 1e0e72e94ee93ca43e97cf7d4a4bad2ac9bddd32308c4c596966c1fda9ae712812ba27c2f76f72efae37160d04d1a349fbe09bc889a3858e52e493b77f7e1a5a
+  checksum: 31d8a809464f7fa700f4baef1ace105d62f8586d249ad56f6b02edeb4cb5be4a97d4109e589fa8e331378f6e8616c7c976dba70b29c71fa7bc32138a73dda91b
   languageName: node
   linkType: hard
 

--- a/extensions/azurePublishNew/yarn-berry.lock
+++ b/extensions/azurePublishNew/yarn-berry.lock
@@ -1936,7 +1936,7 @@ __metadata:
 
 "@bfc/indexers@file:../../Composer/packages/lib/indexers::locator=azure-publish-new%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=07822c&locator=azure-publish-new%40workspace%3A."
+  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=4b3d72&locator=azure-publish-new%40workspace%3A."
   dependencies:
     "@microsoft/bf-lu": 4.15.0-dev.20210702.cbf708d
     adaptive-expressions: ^4.18.0
@@ -1945,7 +1945,7 @@ __metadata:
     tslib: 2.4.0
   peerDependencies:
     "@bfc/shared": "*"
-  checksum: e75d94610a3de51ff52b7ec165e028d9a9ebaceff8db361acbdacc83fdd8d15ee4320bf0771ddf7d163bcb295ed31523a0c3fa1e49bb68a68d4aebbce85b2470
+  checksum: 2e347f39395e735232d68d264714099b744004c7353b310f9fc56bf9c364bba818ecebca58738b3298c038eaf5d09c2c3f3adb768d8c8ea441797d7486ad27a1
   languageName: node
   linkType: hard
 

--- a/extensions/azurePublishNew/yarn-berry.lock
+++ b/extensions/azurePublishNew/yarn-berry.lock
@@ -1936,7 +1936,7 @@ __metadata:
 
 "@bfc/indexers@file:../../Composer/packages/lib/indexers::locator=azure-publish-new%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=99ba57&locator=azure-publish-new%40workspace%3A."
+  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=52caad&locator=azure-publish-new%40workspace%3A."
   dependencies:
     "@microsoft/bf-lu": 4.15.0-dev.20210702.cbf708d
     adaptive-expressions: ^4.18.0
@@ -1945,7 +1945,7 @@ __metadata:
     tslib: 2.4.0
   peerDependencies:
     "@bfc/shared": "*"
-  checksum: 5a2aab3716adf348a98496dd60f07dacb492f8d4e5e393b6cee28d0f39ae5291f5985c4e64f549dde184ec3d49a4a531c1963de19278b89497966fd2fce4373f
+  checksum: 1e0e72e94ee93ca43e97cf7d4a4bad2ac9bddd32308c4c596966c1fda9ae712812ba27c2f76f72efae37160d04d1a349fbe09bc889a3858e52e493b77f7e1a5a
   languageName: node
   linkType: hard
 

--- a/extensions/azurePublishNew/yarn-berry.lock
+++ b/extensions/azurePublishNew/yarn-berry.lock
@@ -1936,7 +1936,7 @@ __metadata:
 
 "@bfc/indexers@file:../../Composer/packages/lib/indexers::locator=azure-publish-new%40workspace%3A.":
   version: 0.0.0
-  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=4b3d72&locator=azure-publish-new%40workspace%3A."
+  resolution: "@bfc/indexers@file:../../Composer/packages/lib/indexers#../../Composer/packages/lib/indexers::hash=99ba57&locator=azure-publish-new%40workspace%3A."
   dependencies:
     "@microsoft/bf-lu": 4.15.0-dev.20210702.cbf708d
     adaptive-expressions: ^4.18.0
@@ -1945,7 +1945,7 @@ __metadata:
     tslib: 2.4.0
   peerDependencies:
     "@bfc/shared": "*"
-  checksum: 2e347f39395e735232d68d264714099b744004c7353b310f9fc56bf9c364bba818ecebca58738b3298c038eaf5d09c2c3f3adb768d8c8ea441797d7486ad27a1
+  checksum: 5a2aab3716adf348a98496dd60f07dacb492f8d4e5e393b6cee28d0f39ae5291f5985c4e64f549dde184ec3d49a4a531c1963de19278b89497966fd2fce4373f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR fixes the issue by adding a new way of indexing the values in the cache object, thus avoiding overwriting the data due to its typing.

## Task Item
Fixes # 9517
#minor

## Screenshots

These images show the user sample and a Microsoft template working successfully with the new indexing.
![image](https://user-images.githubusercontent.com/122501764/223833450-0d9a68e6-431b-46ad-81f7-ce7b8b329bd8.png)
![image](https://user-images.githubusercontent.com/122501764/223830652-725c9bff-6729-474b-9874-e4c71d91b08c.png)
![image](https://user-images.githubusercontent.com/122501764/226457025-63dd2317-532b-4d15-a55a-ce9b70c2d7c6.png)



