### PR TITLE
fix: [#9528] Unable to add two PVA bot skills through bot framework composer with the option connect to a skill

### DIFF
--- a/Composer/packages/client/src/pages/design/ManifestEditor.tsx
+++ b/Composer/packages/client/src/pages/design/ManifestEditor.tsx
@@ -18,7 +18,6 @@ import { Link } from '@fluentui/react/lib/Link';
 import get from 'lodash/get';
 
 import { SkillInfo, skillNameIdentifierByProjectIdSelector } from '../../recoilModel';
-import { isExternalLink } from '../../utils/httpUtil';
 
 import { formEditor } from './styles';
 import { PropertyEditorHeader } from './PropertyEditorHeader';
@@ -76,6 +75,10 @@ const styles = {
 
 const helpLink =
   'https://docs.microsoft.com/en-us/azure/bot-service/skills-write-manifest-2-1?view=azure-bot-service-4.0';
+
+const isExternalLink = (url: string): boolean => {
+  return /^http[s]?:\/\/\w+/.test(url);
+};
 
 export interface ManifestEditorProps {
   formData: SkillInfo;

--- a/Composer/packages/client/src/pages/design/ManifestEditor.tsx
+++ b/Composer/packages/client/src/pages/design/ManifestEditor.tsx
@@ -6,6 +6,8 @@ import { jsx, css } from '@emotion/react';
 import formatMessage from 'format-message';
 import ErrorBoundary from 'react-error-boundary';
 import React from 'react';
+import { useRecoilValue } from 'recoil';
+import { useShellApi } from '@bfc/extension-client';
 import { LoadingTimeout } from '@bfc/adaptive-form/lib/components/LoadingTimeout';
 import { FieldLabel } from '@bfc/adaptive-form/lib/components/FieldLabel';
 import ErrorInfo from '@bfc/adaptive-form/lib/components/ErrorInfo';
@@ -15,7 +17,8 @@ import { DetailsList, DetailsListLayoutMode, SelectionMode } from '@fluentui/rea
 import { Link } from '@fluentui/react/lib/Link';
 import get from 'lodash/get';
 
-import { SkillInfo } from '../../recoilModel';
+import { SkillInfo, skillNameIdentifierByProjectIdSelector } from '../../recoilModel';
+import { isExternalLink } from '../../utils/httpUtil';
 
 import { formEditor } from './styles';
 import { PropertyEditorHeader } from './PropertyEditorHeader';
@@ -82,6 +85,12 @@ export const ManifestEditor: React.FC<ManifestEditorProps> = (props) => {
   const { formData } = props;
   const { manifest } = formData;
 
+  const skillsByProjectId = useRecoilValue(skillNameIdentifierByProjectIdSelector);
+  const { shellApi } = useShellApi();
+
+  const skillNameIdentifier = skillsByProjectId[formData.id];
+  const { displayManifestModal } = shellApi;
+
   if (!manifest) {
     return (
       <LoadingTimeout timeout={2000}>
@@ -117,9 +126,13 @@ export const ManifestEditor: React.FC<ManifestEditorProps> = (props) => {
               label={formatMessage('Manifest URL')}
             />
             <p>
-              <Link aria-label={formData.location} href={formData.location} rel="noopener noreferrer" target="_blank">
-                {formData.location}
-              </Link>
+              {isExternalLink(formData.location) ? (
+                <Link aria-label={formData.location} href={formData.location} rel="noopener noreferrer" target="_blank">
+                  {formData.location}
+                </Link>
+              ) : (
+                <Link onClick={() => manifest && displayManifestModal(skillNameIdentifier)}>{formData.location}</Link>
+              )}
             </p>
           </section>
           <section css={styles.section}>

--- a/Composer/packages/client/src/pages/design/Modals.tsx
+++ b/Composer/packages/client/src/pages/design/Modals.tsx
@@ -146,7 +146,7 @@ const Modals: React.FC<ModalsProps> = ({ projectId = '', rootBotId = '' }) => {
             await addRemoteSkillToBotProject(manifestUrl, endpointName, zipContent);
           }}
           addTriggerToRoot={async (dialogId, formData, skillId) => {
-            await createTriggerForRemoteSkill(projectId, dialogId, formData, skillId);
+            await createTriggerForRemoteSkill(rootBotId, dialogId, formData, skillId);
             commitChanges();
           }}
           projectId={rootBotId}

--- a/Composer/packages/client/src/pages/design/PropertyPanel.tsx
+++ b/Composer/packages/client/src/pages/design/PropertyPanel.tsx
@@ -43,7 +43,7 @@ const PropertyPanel: React.FC<PropertyViewProps> = React.memo(({ projectId = '',
 
     const skillNameIdentifier = skillsByProjectId[projectId];
     return skills[skillNameIdentifier];
-  }, [skills, isSkill, skillsByProjectId]);
+  }, [projectId, skills, isSkill, skillsByProjectId]);
 
   const shellForPropertyEditor = useShell('PropertyEditor', projectId);
 

--- a/Composer/packages/client/src/recoilModel/dispatchers/botProjectFile.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/botProjectFile.ts
@@ -8,12 +8,15 @@ import { CallbackInterface, useRecoilCallback } from 'recoil';
 import { produce } from 'immer';
 import { BotProjectFile, BotProjectSpaceSkill, Skill } from '@bfc/shared';
 
-import { isExternalLink } from '../../utils/httpUtil';
 import { botNameIdentifierState, botProjectFileState, dispatcherState, locationState, settingsState } from '../atoms';
 import { rootBotProjectIdSelector } from '../selectors';
 
 import { setRootBotSettingState } from './setting';
 import { addSkillFiles, deleteSkillFiles } from './utils/skills';
+
+const isExternalLink = (url: string): boolean => {
+  return /^http[s]?:\/\/\w+/.test(url);
+};
 
 export const botProjectFileDispatcher = () => {
   const addLocalSkill = useRecoilCallback(({ set, snapshot }: CallbackInterface) => async (skillId: string) => {

--- a/Composer/packages/client/src/recoilModel/dispatchers/botProjectFile.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/botProjectFile.ts
@@ -8,13 +8,12 @@ import { CallbackInterface, useRecoilCallback } from 'recoil';
 import { produce } from 'immer';
 import { BotProjectFile, BotProjectSpaceSkill, Skill } from '@bfc/shared';
 
+import { isExternalLink } from '../../utils/httpUtil';
 import { botNameIdentifierState, botProjectFileState, dispatcherState, locationState, settingsState } from '../atoms';
 import { rootBotProjectIdSelector } from '../selectors';
 
 import { setRootBotSettingState } from './setting';
 import { addSkillFiles, deleteSkillFiles } from './utils/skills';
-
-const urlRegex = /^http[s]?:\/\/\w+/;
 
 export const botProjectFileDispatcher = () => {
   const addLocalSkill = useRecoilCallback(({ set, snapshot }: CallbackInterface) => async (skillId: string) => {
@@ -52,7 +51,7 @@ export const botProjectFileDispatcher = () => {
       }
       const botName = await snapshot.getPromise(botNameIdentifierState(skillId));
       let finalManifestUrl: string | undefined;
-      if (urlRegex.test(manifestUrl)) {
+      if (isExternalLink(manifestUrl)) {
         finalManifestUrl = manifestUrl;
       } else {
         const data = await addSkillFiles(rootBotProjectId, botName, manifestUrl, zipContent);

--- a/Composer/packages/client/src/recoilModel/dispatchers/project.ts
+++ b/Composer/packages/client/src/recoilModel/dispatchers/project.ts
@@ -6,6 +6,7 @@ import formatMessage from 'format-message';
 import findIndex from 'lodash/findIndex';
 import { PublishTarget, QnABotTemplateId, RootBotManagedProperties } from '@bfc/shared';
 import get from 'lodash/get';
+import camelCase from 'lodash/camelCase';
 import { CallbackInterface, useRecoilCallback } from 'recoil';
 
 import { BotStatus, CreationFlowStatus, FEEDVERSION } from '../../constants';
@@ -196,6 +197,11 @@ export const projectDispatcher = () => {
         if (!rootBotProjectId) return;
 
         const manifestFromZip = getManifestJsonFromZip(zipContent);
+        let botNameIdentifier;
+        if (manifestFromZip.content?.name) {
+          botNameIdentifier = camelCase(manifestFromZip.content.name);
+          manifestFromZip.name = `skills/${botNameIdentifier}/${manifestFromZip.name}`;
+        }
         const botExists = await checkIfBotExistsInBotProjectFile(
           callbackHelpers,
           manifestFromZip.name ? manifestFromZip.name : manifestUrl,
@@ -213,6 +219,7 @@ export const projectDispatcher = () => {
           manifestUrl,
           manifestFromZip,
           rootBotProjectId,
+          botNameIdentifier,
         });
         set(botProjectIdsState, (current) => [...current, projectId]);
         await dispatcher.addRemoteSkillToBotProjectFile(projectId, manifestUrl, zipContent, endpointName);

--- a/Composer/packages/client/src/recoilModel/utils/skill.ts
+++ b/Composer/packages/client/src/recoilModel/utils/skill.ts
@@ -24,7 +24,7 @@ export const getManifestJsonFromZip = (zipContent) => {
   try {
     const manifestUrl = Object.keys(zipContent).find((key) => zipContent[key] && isManifestJson(zipContent[key]));
     return manifestUrl
-      ? { name: `skills/${manifestUrl}`, content: JSON.parse(zipContent[manifestUrl]) }
+      ? { name: manifestUrl, content: JSON.parse(zipContent[manifestUrl]) }
       : { name: '', content: null };
   } catch (e) {
     return { name: '', content: null };

--- a/Composer/packages/client/src/utils/httpUtil.ts
+++ b/Composer/packages/client/src/utils/httpUtil.ts
@@ -5,6 +5,11 @@ import { createAxios } from '@bfc/shared/lib/axios';
 
 import { BASEURL } from '../constants';
 
+/* Returns true if the url starts with http or https */
+export const isExternalLink = (url: string): boolean => {
+  return /^http[s]?:\/\/\w+/.test(url);
+};
+
 const httpClient = createAxios({
   baseURL: BASEURL,
 });

--- a/Composer/packages/client/src/utils/httpUtil.ts
+++ b/Composer/packages/client/src/utils/httpUtil.ts
@@ -5,11 +5,6 @@ import { createAxios } from '@bfc/shared/lib/axios';
 
 import { BASEURL } from '../constants';
 
-/* Returns true if the url starts with http or https */
-export const isExternalLink = (url: string): boolean => {
-  return /^http[s]?:\/\/\w+/.test(url);
-};
-
 const httpClient = createAxios({
   baseURL: BASEURL,
 });

--- a/Composer/packages/server/src/models/utilities/util.ts
+++ b/Composer/packages/server/src/models/utilities/util.ts
@@ -40,5 +40,11 @@ export const getRemoteFile = async (url): Promise<string> => {
 
 // convert zip folder name to skill name
 export const convertFolderNameToSkillName = (path, skillName) => {
-  return path.replace(/(\w+)\//, `${skillName}/`);
+  const hasFolder = path.match(/(\w+)\//);
+
+  if (hasFolder === null) {
+    return `${skillName}/${path}`;
+  }
+
+  return path.replace(hasFolder[0], `${skillName}/`);
 };


### PR DESCRIPTION
## Description
This PR fixes an issue where Composer fails to connect to multiple PVA skills due to a validation error saying "The skill is already part of the Bot Project". This validation happened because a single manifest was saved in the `skills` folder, and adding another PVA bot will replace it.
Therefore, changing the folder structure to where the bot's manifest is saved solved the issue.
Other issues have been addressed due to being related to PVA skills, where:
- The Manifest URL didn't redirect to a valid content, since the bot was loaded from a `.zip` file and no endpoint was available.
  - Instead of redirecting to the `manifest.json` file, it shows its content in a modal.
- Switching between PVA skill pages, the information didn't get refreshed.
  - Adding the `projectId` to the `useMemo` function solved the issue.
- When a PVA skill is added and the visual focus is on another bot that is not the root, it will throw an error that it didn't locate `.lg` and `.lu` files, failing to add the skill action trigger to the root bot.
  - Changing the current opened bot project id to use the root one, solved the issue.

## Task Item
#minor
Fixes # 9528

## Screenshots
The following images show the validation when adding an existing PVA skill and the folder structure, and the bots working as expected.
![image](https://user-images.githubusercontent.com/62260472/228259346-38b60381-873c-47b9-801b-18782462addb.png)
![image](https://user-images.githubusercontent.com/62260472/228259385-76d982d2-0004-4eb1-8f29-eff533a7bbda.png)