### PR TITLE
fix: Update express-session MemoryStore

### DIFF
--- a/Composer/packages/server/package.json
+++ b/Composer/packages/server/package.json
@@ -109,6 +109,7 @@
     "jwks-rsa": "^1.6.0",
     "lodash": "^4.17.19",
     "luis-apis": "2.5.1",
+    "memorystore": "1.6.7",
     "minimatch": "^3.0.4",
     "moment": "^2.29.1",
     "morgan": "^1.9.1",

--- a/Composer/packages/server/src/server.ts
+++ b/Composer/packages/server/src/server.ts
@@ -40,6 +40,7 @@ import { serverListenHost, serverHostname } from './settings/env';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const session = require('express-session');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const MemoryStore = require('memorystore')(session);
 
 export async function start(electronContext?: ElectronContext): Promise<number | string> {
@@ -56,12 +57,14 @@ export async function start(electronContext?: ElectronContext): Promise<number |
 
   app.use(bodyParser.json({ limit: '50mb' }) as any);
   app.use(bodyParser.urlencoded({ extended: false }) as any);
-  app.use(session({
-    store: new MemoryStore(),
-    secret: 'bot-framework-composer',
-    resave: true,
-    saveUninitialized: false,
-  }));
+  app.use(
+    session({
+      store: new MemoryStore(),
+      secret: 'bot-framework-composer',
+      resave: true,
+      saveUninitialized: false,
+    })
+  );
   app.use(ExtensionContext.passport.initialize());
   app.use(ExtensionContext.passport.session());
 

--- a/Composer/packages/server/src/server.ts
+++ b/Composer/packages/server/src/server.ts
@@ -40,6 +40,7 @@ import { serverListenHost, serverHostname } from './settings/env';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const session = require('express-session');
+const MemoryStore = require('memorystore')(session);
 
 export async function start(electronContext?: ElectronContext): Promise<number | string> {
   setEnvDefault('COMPOSER_VERSION', getVersion());
@@ -55,7 +56,12 @@ export async function start(electronContext?: ElectronContext): Promise<number |
 
   app.use(bodyParser.json({ limit: '50mb' }) as any);
   app.use(bodyParser.urlencoded({ extended: false }) as any);
-  app.use(session({ secret: 'bot-framework-composer' }));
+  app.use(session({
+    store: new MemoryStore(),
+    secret: 'bot-framework-composer',
+    resave: true,
+    saveUninitialized: false,
+  }));
   app.use(ExtensionContext.passport.initialize());
   app.use(ExtensionContext.passport.session());
 

--- a/Composer/yarn-berry.lock
+++ b/Composer/yarn-berry.lock
@@ -4194,6 +4194,7 @@ __metadata:
     jwks-rsa: ^1.6.0
     lodash: ^4.17.19
     luis-apis: 2.5.1
+    memorystore: 1.6.7
     minimatch: ^3.0.4
     mock-fs: ^4.10.1
     moment: ^2.29.1
@@ -12899,7 +12900,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.3.4":
+"debug@npm:^4.3.0, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -20371,7 +20372,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^4.0.1":
+"lru-cache@npm:^4.0.1, lru-cache@npm:^4.0.3":
   version: 4.1.5
   resolution: "lru-cache@npm:4.1.5"
   dependencies:
@@ -20746,6 +20747,16 @@ __metadata:
     errno: ^0.1.3
     readable-stream: ^2.0.1
   checksum: a9f25b0a8ecfb7324277393f19ef68e6ba53b9e6e4b526bbf2ba23055c5440fbf61acc7bf66bfd980e9eb4951a4790f6f777a9a3abd36603f22c87e8a64d3d6b
+  languageName: node
+  linkType: hard
+
+"memorystore@npm:1.6.7":
+  version: 1.6.7
+  resolution: "memorystore@npm:1.6.7"
+  dependencies:
+    debug: ^4.3.0
+    lru-cache: ^4.0.3
+  checksum: caa5cc523ec39ad8b317ddb5560771df28a10266281066f554bd77b2179a34f21f06891fffbcfe875ed1afc79cf7e106714eff98189ded1e6bfc273159d07948
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#minor

## Description
This PR replaces the `express-session` internal store with a custom one ([MemoryStore](https://www.npmjs.com/package/memorystore)) to reduce possible memory leaks.

Memory leak warning ([more information](https://expressjs.com/en/resources/middleware/session.html)):
> _Warning The default server-side session storage, MemoryStore, is purposely not designed for a production environment. It will leak memory under most conditions, does not scale past a single process, and is meant for debugging and developing._
> _For a list of stores, see [compatible session stores](https://expressjs.com/en/resources/middleware/session.html#compatible-session-stores)._

## Screenshots
The following image shows the before and after the implementation of the new store.
![image](https://user-images.githubusercontent.com/62260472/236913172-eacb06ec-6298-4b93-88d9-b1eb084999c1.png)