### PR TITLE
Fix error when loading exported bot

### DIFF
--- a/Composer/packages/server/src/models/bot/botStructure.ts
+++ b/Composer/packages/server/src/models/bot/botStructure.ts
@@ -32,6 +32,7 @@ const BotStructureTemplate = {
   formDialogs: 'form-dialogs/${FORMDIALOGNAME}',
   skillManifests: 'manifests/${MANIFESTFILENAME}',
   botProject: '${BOTNAME}.botproj',
+  botCsProject: '${BOTNAME}.csproj',
   recognizer: 'recognizers/${RECOGNIZERNAME}',
   crossTrainConfig: 'settings/${CROSSTRAINCONFIGNAME}',
   // PVA
@@ -81,6 +82,7 @@ export const BotStructureFilesPatterns = [
   templateInterpolate(BotStructureTemplate.formDialogs, { FORMDIALOGNAME: '*.form' }),
   templateInterpolate(BotStructureTemplate.skillManifests, { MANIFESTFILENAME: '*.json' }),
   templateInterpolate(BotStructureTemplate.botProject, { BOTNAME: '*' }),
+  templateInterpolate(BotStructureTemplate.botCsProject, { BOTNAME: '*' }),
   templateInterpolate(BotStructureTemplate.recognizer, { RECOGNIZERNAME: '*.dialog' }),
   templateInterpolate(BotStructureTemplate.crossTrainConfig, { CROSSTRAINCONFIGNAME: 'cross-train.config.json' }),
   '*.schema',

--- a/Composer/packages/server/src/utility/project.ts
+++ b/Composer/packages/server/src/utility/project.ts
@@ -68,7 +68,7 @@ export async function ejectAndMerge(currentProject: BotProject, jobId: string) {
       BackgroundProcessManager.updateProcess(jobId, 202, formatMessage('Building runtime'));
       await runtime.build(runtimePath, currentProject);
 
-      const manifestFile = runtime.identifyManifest(currentProject.dataDir, currentProject.name);
+      const manifestFile = runtime.identifyManifest(currentProject.dataDir, currentProject);
 
       // run the merge command to merge all package dependencies from the template to the bot project
       BackgroundProcessManager.updateProcess(jobId, 202, formatMessage('Merging Packages'));

--- a/Composer/packages/types/src/runtime.ts
+++ b/Composer/packages/types/src/runtime.ts
@@ -77,7 +77,7 @@ export type RuntimeTemplate = {
 
   uninstallComponent: (runtimePath: string, componentName: string, project: IBotProject) => Promise<string>;
 
-  identifyManifest: (runtimePath: string, projName?: string) => string;
+  identifyManifest: (runtimePath: string, project: IBotProject) => string;
 
   /** build for deploy method */
   buildDeploy: (

--- a/extensions/azurePublish/yarn-berry.lock
+++ b/extensions/azurePublish/yarn-berry.lock
@@ -1970,7 +1970,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=azurePublish%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=azurePublish%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=755bee&locator=azurePublish%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -1979,7 +1979,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
+  checksum: 3c4b321b013669a616dac1b8e90b8632b197d62253b632f9c95e4356c259331e754452747ab3bde211f259f2458e40d057cc3070daaf40dd496b421646fb2632
   languageName: node
   linkType: hard
 

--- a/extensions/azurePublishNew/yarn-berry.lock
+++ b/extensions/azurePublishNew/yarn-berry.lock
@@ -2010,7 +2010,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=azure-publish-new%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=azure-publish-new%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=755bee&locator=azure-publish-new%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -2019,7 +2019,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
+  checksum: 3c4b321b013669a616dac1b8e90b8632b197d62253b632f9c95e4356c259331e754452747ab3bde211f259f2458e40d057cc3070daaf40dd496b421646fb2632
   languageName: node
   linkType: hard
 

--- a/extensions/localPublish/yarn-berry.lock
+++ b/extensions/localPublish/yarn-berry.lock
@@ -7,7 +7,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=localpublish%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=localpublish%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=755bee&locator=localpublish%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -16,7 +16,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
+  checksum: 3c4b321b013669a616dac1b8e90b8632b197d62253b632f9c95e4356c259331e754452747ab3bde211f259f2458e40d057cc3070daaf40dd496b421646fb2632
   languageName: node
   linkType: hard
 

--- a/extensions/mockRemotePublish/yarn-berry.lock
+++ b/extensions/mockRemotePublish/yarn-berry.lock
@@ -7,7 +7,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=mockRemotePublish%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=mockRemotePublish%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=755bee&locator=mockRemotePublish%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -16,7 +16,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
+  checksum: 3c4b321b013669a616dac1b8e90b8632b197d62253b632f9c95e4356c259331e754452747ab3bde211f259f2458e40d057cc3070daaf40dd496b421646fb2632
   languageName: node
   linkType: hard
 

--- a/extensions/packageManager/src/node/index.ts
+++ b/extensions/packageManager/src/node/index.ts
@@ -251,7 +251,7 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
       const runtimePath = currentProject.getRuntimePath();
 
       if (currentProject.settings?.runtime?.customRuntime && runtimePath) {
-        const manifestFile = runtime.identifyManifest(runtimePath, currentProject.name);
+        const manifestFile = runtime.identifyManifest(runtimePath, currentProject);
 
         const dryrun = new SchemaMerger(
           [manifestFile, `!${path.join(currentProject.dir, 'generated')}/**`],
@@ -314,7 +314,7 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
             currentProject
           );
 
-          const manifestFile = runtime.identifyManifest(runtimePath, currentProject.name);
+          const manifestFile = runtime.identifyManifest(runtimePath, currentProject);
 
           // call do a dry run on the dialog merge
           const dryrun = new SchemaMerger(
@@ -453,7 +453,7 @@ export default async (composer: IExtensionRegistration): Promise<void> => {
         try {
           const output = await runtime.uninstallComponent(runtimePath, packageName, currentProject);
 
-          const manifestFile = runtime.identifyManifest(runtimePath, currentProject.name);
+          const manifestFile = runtime.identifyManifest(runtimePath, currentProject);
 
           // call do a dry run on the dialog merge
           const merger = new SchemaMerger(

--- a/extensions/packageManager/yarn-berry.lock
+++ b/extensions/packageManager/yarn-berry.lock
@@ -154,7 +154,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=package-manager%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=package-manager%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=755bee&locator=package-manager%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -163,7 +163,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
+  checksum: 3c4b321b013669a616dac1b8e90b8632b197d62253b632f9c95e4356c259331e754452747ab3bde211f259f2458e40d057cc3070daaf40dd496b421646fb2632
   languageName: node
   linkType: hard
 

--- a/extensions/pvaPublish/yarn-berry.lock
+++ b/extensions/pvaPublish/yarn-berry.lock
@@ -1643,7 +1643,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=pva-publish-composer%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=pva-publish-composer%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=755bee&locator=pva-publish-composer%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -1652,7 +1652,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
+  checksum: 3c4b321b013669a616dac1b8e90b8632b197d62253b632f9c95e4356c259331e754452747ab3bde211f259f2458e40d057cc3070daaf40dd496b421646fb2632
   languageName: node
   linkType: hard
 

--- a/extensions/runtimes/yarn-berry.lock
+++ b/extensions/runtimes/yarn-berry.lock
@@ -7,7 +7,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=plugin-runtimes%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=plugin-runtimes%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=755bee&locator=plugin-runtimes%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -16,7 +16,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
+  checksum: 3c4b321b013669a616dac1b8e90b8632b197d62253b632f9c95e4356c259331e754452747ab3bde211f259f2458e40d057cc3070daaf40dd496b421646fb2632
   languageName: node
   linkType: hard
 

--- a/extensions/sample-ui-plugin/yarn-berry.lock
+++ b/extensions/sample-ui-plugin/yarn-berry.lock
@@ -104,7 +104,7 @@ __metadata:
 
 "@botframework-composer/types@file:../../Composer/packages/types::locator=sample-ui-plugin%40workspace%3A.":
   version: 0.0.2
-  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=d657f3&locator=sample-ui-plugin%40workspace%3A."
+  resolution: "@botframework-composer/types@file:../../Composer/packages/types#../../Composer/packages/types::hash=755bee&locator=sample-ui-plugin%40workspace%3A."
   dependencies:
     "@types/express": 4.16.1
     "@types/passport": ^1.0.4
@@ -113,7 +113,7 @@ __metadata:
     express-serve-static-core: 0.1.1
     json-schema: 0.4.0
     tslib: 2.4.0
-  checksum: b085f9dddc37d8e77c723814f40c0551dd68f9a45e40ef64cbe51ed956f7ff64a266ea4fcc35144e352cadf6a657ac9fa6d0f74b90ea362d39104a26cf88c643
+  checksum: 3c4b321b013669a616dac1b8e90b8632b197d62253b632f9c95e4356c259331e754452747ab3bde211f259f2458e40d057cc3070daaf40dd496b421646fb2632
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR updates the C# runtime to use the name of the _.csproj_ as the project name instead of the folder name. This change allows loading and executing bots previously exported where its containing folder differs from the original project name.

## Task Item
#minor
Related Components issue: [# 1500](https: //github.com/microsoft/botframework-components/issues/ 1500)

### Detailed Changes
- Updated model in **_BotStructure_** to include the _.csproj_ file in the project's files list.
- Updated the runtime's **_identifyManifest_** method to receive the _botProject_ object instead of the project name.
- Updated calls to _identifyManifest_ in **_packageManager_** index file.
- Updated **_runtimes_** index to use the _.csproj_ name in the different dotnet commands to initialize, build and publish the bot.
- Updated all the affected **_yarn-berry.lock_** files.

## Screenshots
These images show the previously exported bot working in Composer.
![image](https://github.com/southworks/BotFramework-Composer/assets/44245136/bd7659ba-edbb-401f-bf4f-073c6278cc96)