### PR TITLE
Optimize memory usage when parsing LgFiles

### DIFF
--- a/Composer/packages/client/src/App.tsx
+++ b/Composer/packages/client/src/App.tsx
@@ -45,10 +45,10 @@ export const App: React.FC = () => {
   }, [appLocale]);
 
   useEffect(() => {
-    lgWorker.listen(LgEventType.OnUpdateLgFile, msg => {
+    lgWorker.listen(LgEventType.OnUpdateLgFile, (msg) => {
       const { projectId, payload } = msg.data;
       updateFile({ projectId, value: payload });
-    })
+    });
   });
 
   useEffect(() => {

--- a/Composer/packages/client/src/recoilModel/parsers/lgWorker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/lgWorker.ts
@@ -6,6 +6,7 @@ import Worker from './workers/lgParser.worker.ts';
 import { BaseWorker } from './baseWorker';
 import {
   LgActionType,
+  LgEventType,
   LgParsePayload,
   LgUpdateTemplatePayload,
   LgCreateTemplatePayload,
@@ -20,6 +21,38 @@ import {
 
 // Wrapper class
 class LgWorker extends BaseWorker<LgActionType> {
+  private listeners = new Map<LgEventType, ((msg: MessageEvent) => void)[]>();
+
+  constructor(worker: Worker) {
+    super(worker);
+
+    worker.onmessage = (msg) => {
+      const { type } = msg.data;
+
+      if (type === LgEventType.OnUpdateLgFile) {
+        this.listeners.get(type)?.forEach((cb) => cb(msg));
+      } else {
+        this.handleMsg(msg);
+      }
+    };
+  }
+
+  listen(action: LgEventType, callback: (msg: MessageEvent) => void) {
+    if (this.listeners.has(action)) {
+      this.listeners.get(action)!.push(callback);
+    } else {
+      this.listeners.set(action, [callback]);
+    }
+  }
+
+  async flush(): Promise<boolean> {
+    return new Promise(async (resolve) => {
+      this.listeners.clear();
+      const result = await super.flush();
+      resolve(result);
+    });
+  }
+
   addProject(projectId: string) {
     return this.sendMsg<LgNewCachePayload>(LgActionType.NewCache, { projectId });
   }

--- a/Composer/packages/client/src/recoilModel/parsers/lgWorker.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/lgWorker.ts
@@ -45,12 +45,9 @@ class LgWorker extends BaseWorker<LgActionType> {
     }
   }
 
-  async flush(): Promise<boolean> {
-    return new Promise(async (resolve) => {
-      this.listeners.clear();
-      const result = await super.flush();
-      resolve(result);
-    });
+  flush(): Promise<boolean> {
+    this.listeners.clear();
+    return super.flush();
   }
 
   addProject(projectId: string) {

--- a/Composer/packages/client/src/recoilModel/parsers/types.ts
+++ b/Composer/packages/client/src/recoilModel/parsers/types.ts
@@ -156,6 +156,10 @@ export enum LgActionType {
   ParseAll = 'parse-all',
 }
 
+export enum LgEventType {
+  OnUpdateLgFile = 'on-update-lgfile',
+}
+
 export enum IndexerActionType {
   Index = 'index',
 }

--- a/Composer/packages/client/src/recoilModel/utils/mapOptimizer.ts
+++ b/Composer/packages/client/src/recoilModel/utils/mapOptimizer.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 interface MapOptimizerTree<Key> {
   timestamp: number;
   references: Key[];
@@ -11,7 +14,7 @@ export class MapOptimizer<Key, Value> {
   public tree = new Map<Key, MapOptimizerTree<Key>>();
   private skipOptimize = new Set<Key>();
 
-  opUpdateCallback?: (key: Key, value: Value, ctx: OnUpdateMapOptimizerContext<Key>) => void;
+  onUpdateCallback?: (key: Key, value: Value, ctx: OnUpdateMapOptimizerContext<Key>) => void;
   onDeleteCallback?: (key: Key, value: Value) => void;
 
   constructor(private capacity: number, public list: Map<Key, Value>) {
@@ -19,7 +22,7 @@ export class MapOptimizer<Key, Value> {
   }
 
   onUpdate(callback: (key: Key, value: Value, ctx: OnUpdateMapOptimizerContext<Key>) => void) {
-    this.opUpdateCallback = callback;
+    this.onUpdateCallback = callback;
   }
 
   onDelete(callback: (key: Key, value: Value) => void) {
@@ -40,7 +43,7 @@ export class MapOptimizer<Key, Value> {
   private optimize(keyToAdd: Key, valueToAdd: Value) {
     const exists = this.tree.has(keyToAdd);
     const context: MapOptimizerTree<Key> = { timestamp: Date.now(), references: [] };
-    this.opUpdateCallback?.(keyToAdd, valueToAdd, {
+    this.onUpdateCallback?.(keyToAdd, valueToAdd, {
       setReferences: (references) => (context.references = references || []),
     });
     this.tree.set(keyToAdd, context);

--- a/Composer/packages/client/src/recoilModel/utils/mapOptimizer.ts
+++ b/Composer/packages/client/src/recoilModel/utils/mapOptimizer.ts
@@ -1,0 +1,100 @@
+interface MapOptimizerTree<Key> {
+  timestamp: number;
+  references: Key[];
+}
+
+interface OnUpdateMapOptimizerContext<Key> {
+  setReferences(references: Key[]): void;
+}
+
+export class MapOptimizer<Key, Value> {
+  public tree = new Map<Key, MapOptimizerTree<Key>>();
+  private skipOptimize = new Set<Key>();
+
+  opUpdateCallback?: (key: Key, value: Value, ctx: OnUpdateMapOptimizerContext<Key>) => void;
+  onDeleteCallback?: (key: Key, value: Value) => void;
+
+  constructor(private capacity: number, public list: Map<Key, Value>) {
+    this.attach();
+  }
+
+  onUpdate(callback: (key: Key, value: Value, ctx: OnUpdateMapOptimizerContext<Key>) => void) {
+    this.opUpdateCallback = callback;
+  }
+
+  onDelete(callback: (key: Key, value: Value) => void) {
+    this.onDeleteCallback = callback;
+  }
+
+  private attach() {
+    const set = this.list.set;
+    this.list.set = (key, value) => {
+      if (!this.skipOptimize.has(key)) {
+        this.optimize(key, value);
+      }
+      const result = set.apply(this.list, [key, value]);
+      return result;
+    };
+  }
+
+  private optimize(keyToAdd: Key, valueToAdd: Value) {
+    const exists = this.tree.has(keyToAdd);
+    const context: MapOptimizerTree<Key> = { timestamp: Date.now(), references: [] };
+    this.opUpdateCallback?.(keyToAdd, valueToAdd, {
+      setReferences: (references) => (context.references = references || []),
+    });
+    this.tree.set(keyToAdd, context);
+
+    if (exists) {
+      return;
+    }
+
+    let processed: [Key, MapOptimizerTree<Key>][] = [];
+    const itemsToRemove = Array.from(this.tree.entries())
+      .filter(([key]) => key !== keyToAdd)
+      .sort(([, v1], [, v2]) => v2.timestamp - v1.timestamp);
+
+    while (this.capacity < this.tree.size) {
+      const itemToRemove = itemsToRemove.pop();
+      if (!itemToRemove) {
+        break;
+      }
+
+      const [key, { references }] = itemToRemove;
+      const ids = this.identify([key, ...references]);
+
+      // Re-process previous items if an item gets deleted.
+      processed.push(itemToRemove);
+      if (ids.length > 0) {
+        itemsToRemove.push(...processed);
+        processed = [];
+      }
+
+      for (const id of ids) {
+        this.tree.delete(id);
+        const listItem = this.list.get(id)!;
+        this.skipOptimize.add(id);
+        this.onDeleteCallback ? this.onDeleteCallback(id, listItem) : this.list.delete(id);
+        this.skipOptimize.delete(id);
+      }
+    }
+  }
+
+  private identify(references: Key[], memo: Key[] = []) {
+    for (const reference of references) {
+      const found = this.tree.get(reference);
+      const existsOnMemo = () => memo.some((e) => found!.references.includes(e));
+      const existsOnReferences = () =>
+        Array.from(this.tree.values()).some(({ references }) => references.includes(reference));
+
+      if (!found || existsOnMemo() || existsOnReferences()) {
+        continue;
+      }
+
+      memo.push(reference);
+      this.identify(found.references, memo);
+    }
+
+    return memo;
+  }
+}


### PR DESCRIPTION
#minor

## Description
This PR reduces the memory usage when parsing the LgFiles ([lgParse.worker](https://github.com/microsoft/BotFramework-Composer/blob/main/Composer/packages/client/src/recoilModel/parsers/workers/lgParser.worker.ts)) by adding a `MapOptimizer` to the `LgFilesCache`.
This optimizer consists of, based on a capacity limit, the process will start removing LgFile parse results to free up space from memory. Additionally, it takes into account all the references and relationships between other LgFiles.

> **Note**: The `MapOptimizer` capacity limit is set to store a maximum of 10 parsed LgFiles, this amount can be modified through code.

## Screenshots
The following image shows loading 9 bot responses with the `MapOptimizer` capacity size of 3 (for testing purposes), seeing the improvement in memory usage.
![image](https://github.com/southworks/BotFramework-Composer/assets/62260472/ba340007-d894-416e-9a72-c75d5d074b61)